### PR TITLE
[POC] typed dsl

### DIFF
--- a/helios-optics/src/main/kotlin/helios/optics/JsonPath.kt
+++ b/helios-optics/src/main/kotlin/helios/optics/JsonPath.kt
@@ -1,9 +1,12 @@
 package helios.optics
 
 import arrow.core.*
+import arrow.free.free
 import arrow.optics.*
 import arrow.optics.typeclasses.*
 import helios.core.*
+import helios.instances.StringDecoderInstance
+import helios.instances.StringEncoderInstance
 import helios.typeclasses.*
 
 /**
@@ -11,13 +14,13 @@ import helios.typeclasses.*
  *
  * With [JsonPath] you can represent paths/relations within your [Json] and allows for working with [Json] in an elegant way.
  */
-data class JsonPath(val json: Optional<Json, Json>) {
+data class JsonPath(override val json: Optional<Json, Json>): JsonPathFunctions<POptional.ForOptional> {
 
     companion object {
         /**
          * [JsonPath] [root] which is the start of any path.
          */
-        val root = JsonPath(Optional.id())
+        val root: JsonPathFunctions<POptional.ForOptional> = JsonPath(Optional.id())
 
         /**
          * Overload constructor to point to [root].
@@ -28,94 +31,99 @@ data class JsonPath(val json: Optional<Json, Json>) {
     /**
      * Extract value as [Boolean] from path.
      */
-    val boolean: Optional<Json, Boolean> = json compose jsonJsBoolean() compose jsBooleanIso()
+    override val boolean: Optional<Json, Boolean> = json compose jsonJsBoolean() compose jsBooleanIso()
+
+    /**
+     * Extract value as [CharSequence] from path.
+     */
+    override val charseq: Optional<Json, CharSequence> = json compose jsonJsString() compose  jsStringIso()
 
     /**
      * Extract value as [String] from path.
      */
-    val string: Optional<Json, CharSequence> = json compose jsonJsString() compose jsStringIso()
+    override val string: Optional<Json, String> = extract(StringEncoderInstance, StringDecoderInstance)
 
     /**
      * Extract value as [JsNumber] from path.
      */
-    val number: Optional<Json, JsNumber> = json compose jsonJsNumber()
+    override val number: Optional<Json, JsNumber> = json compose jsonJsNumber()
 
     /**
      * Extract value as [JsDecimal] from path.
      */
-    val decimal: Optional<Json, String> = number compose jsNumberJsDecimal() compose jsDecimalIso()
+    override val decimal: Optional<Json, String> = number compose jsNumberJsDecimal() compose jsDecimalIso()
 
     /**
      * Extract value as [Long] from path.
      */
-    val long: Optional<Json, Long> = number compose jsNumberJsLong() compose jsLongIso()
+    override val long: Optional<Json, Long> = number compose jsNumberJsLong() compose jsLongIso()
 
     /**
      * Extract value as [Float] from path.
      */
-    val float: Optional<Json, Float> = number compose jsNumberJsFloat() compose jsFloatIso()
+    override val float: Optional<Json, Float> = number compose jsNumberJsFloat() compose jsFloatIso()
 
     /**
      * Extract value as [Int] from path.
      */
-    val int: Optional<Json, Int> = number compose jsNumberJsInt() compose jsIntIso()
+    override val int: Optional<Json, Int> = number compose jsNumberJsInt() compose jsIntIso()
 
     /**
      * Extract [JsArray] as `List<Json>` from path.
      */
-    val array: Optional<Json, List<Json>> = json compose jsonJsArray() compose jsArrayIso()
+    override val array: Optional<Json, List<Json>> = json compose jsonJsArray() compose jsArrayIso()
 
     /**
      * Extract [JsObject] as `Map<String, Json>` from path.
      */
-    val `object`: Optional<Json, Map<String, Json>> = json compose jsonJsObject() compose jsObjectIso()
+    override val `object`: Optional<Json, Map<String, Json>> = json compose jsonJsObject() compose jsObjectIso()
 
     /**
      * Extract [JsNull] from path.
      */
-    val `null`: Optional<Json, JsNull> = json compose jsonJsNull()
+    override val `null`: Optional<Json, JsNull> = json compose jsonJsNull()
 
     /**
      * Select field with [name] in [JsObject] from path.
      */
-    fun select(name: String) = JsonPath(json compose jsonJsObject() compose Index.index(name))
+    override fun select(name: String) = JsonPath(json compose jsonJsObject() compose index<JsObject, String, Json>().index(name).asHPOptional())
 
     /**
      * Extract field with [name] from [JsObject] from path.
      */
-    fun at(field: String): Optional<Json, Option<Json>> = json compose jsonJsObject() compose At.at(field)
+    override fun at(field: String): Optional<Json, Option<Json>> = json compose jsonJsObject() compose At.at(field)
 
     /**
      *  Get element at index [i] from [JsArray].
      */
-    operator fun get(i: Int) = JsonPath(json compose jsonJsArray() compose Index.index(i))
+    override operator fun get(i: Int) = JsonPath(json compose jsonJsArray() compose index<JsArray, Int, Json>().index(i).asHPOptional())
 
     /**
      * Extract [A] from path.
      */
-    fun <A> extract(DE: Decoder<A>, EN: Encoder<A>): Optional<Json, A> =
+    override fun <A> extract(DE: Decoder<A>, EN: Encoder<A>): Optional<Json, A> =
             json compose parse(DE, EN)
 
     /**
      * Select field with [name] in [JsObject] and extract as [A] from path.
      */
-    fun <A> selectExtract(DE: Decoder<A>, EN: Encoder<A>, name: String): Optional<Json, A> =
+    override fun <A> selectExtract(DE: Decoder<A>, EN: Encoder<A>, name: String): Optional<Json, A> =
             select(name).extract(DE, EN)
 
     /**
      * Select every entry in [JsObject] or [JsArray].
      */
-    fun every() = JsonTraversalPath(json compose jsonTraversal)
+    override fun every() = JsonTraversalPath(json compose jsonTraversal)
 
     /**
      * Filter [JsArray] by indices that satisfy the predicate [p].
      */
-    fun filterIndex(p: Predicate<Int>) = JsonTraversalPath(array compose FilterIndex.filterIndex(p = p))
+    override fun filterIndex(p: Predicate<Int>) = JsonTraversalPath(array compose filterIndex<List<Json>, Int, Json>().filter(p).asHPTraversal())
 
     /**
      * Filter [JsObject] by keys that satisfy the predicate [p].
      */
-    fun filterKeys(p: Predicate<String>) = JsonTraversalPath(`object` compose FilterIndex.filterIndex(p = p))
+    override fun filterKeys(p: Predicate<String>) = JsonTraversalPath(`object` compose filterIndex<Map<String, Json>, String, Json>().filter(p).asHPTraversal())
 
 }
 

--- a/helios-optics/src/main/kotlin/helios/optics/JsonPathFunctions.kt
+++ b/helios-optics/src/main/kotlin/helios/optics/JsonPathFunctions.kt
@@ -1,0 +1,131 @@
+package helios.optics
+
+import arrow.core.Option
+import arrow.core.Predicate
+import helios.core.JsArray
+import helios.core.JsDecimal
+import helios.core.JsNull
+import helios.core.JsNumber
+import helios.core.JsObject
+import helios.core.Json
+import helios.core.jsArrayIso
+import helios.core.jsBooleanIso
+import helios.core.jsDecimalIso
+import helios.core.jsFloatIso
+import helios.core.jsIntIso
+import helios.core.jsLongIso
+import helios.core.jsNumberJsDecimal
+import helios.core.jsNumberJsFloat
+import helios.core.jsNumberJsInt
+import helios.core.jsNumberJsLong
+import helios.core.jsObjectIso
+import helios.core.jsStringIso
+import helios.core.jsonJsArray
+import helios.core.jsonJsBoolean
+import helios.core.jsonJsNull
+import helios.core.jsonJsNumber
+import helios.core.jsonJsObject
+import helios.core.jsonJsString
+import helios.typeclasses.Decoder
+import helios.typeclasses.Encoder
+import helios.typeclasses.decoder
+import helios.typeclasses.encoder
+
+interface JsonPathFunctions<F> {
+
+    val json: Kind4<F, Json, Json, Json, Json>
+
+    /**
+     * Extract value as [Boolean] from path.
+     */
+    val boolean: Kind4<F, Json, Json, Boolean, Boolean>
+
+    /**
+     * Extract value as [String] from path.
+     */
+    val charseq: Kind4<F, Json, Json, CharSequence, CharSequence>
+
+    /**
+     * Extract value as [String] from path.
+     */
+    val string: Kind4<F, Json, Json, String, String>
+
+    /**
+     * Extract value as [JsNumber] from path.
+     */
+    val number: Kind4<F, Json, Json, JsNumber, JsNumber>
+
+    /**
+     * Extract value as [JsDecimal] from path.
+     */
+    val decimal: Kind4<F, Json, Json, String, String>
+
+    /**
+     * Extract value as [Long] from path.
+     */
+    val long: Kind4<F, Json, Json, Long, Long>
+    /**
+     * Extract value as [Float] from path.
+     */
+    val float: Kind4<F, Json, Json, Float, Float>
+
+    /**
+     * Extract value as [Int] from path.
+     */
+    val int: Kind4<F, Json, Json, Int, Int>
+
+    /**
+     * Extract [JsArray] as `List<Json>` from path.
+     */
+    val array: Kind4<F, Json, Json, List<Json>, List<Json>>
+
+    /**
+     * Extract [JsObject] as `Map<String, Json>` from path.
+     */
+    val `object`: Kind4<F, Json, Json, Map<String, Json>, Map<String, Json>>
+
+    /**
+     * Extract [JsNull] from path.
+     */
+    val `null`: Kind4<F, Json, Json, JsNull, JsNull>
+
+    /**
+     * Select field with [name] in [JsObject] from path.
+     */
+    fun select(name: String): JsonPathFunctions<F>
+
+    /**
+     * Extract field with [name] from [JsObject] from path.
+     */
+    fun at(field: String): Kind4<F, Json, Json, Option<Json>, Option<Json>>
+
+    /**
+     *  Get element at index [i] from [JsArray].
+     */
+    operator fun get(i: Int): JsonPathFunctions<F>
+
+    /**
+     * Extract [A] from path.
+     */
+    fun <A> extract(DE: Decoder<A>, EN: Encoder<A>): Kind4<F, Json, Json, A, A>
+
+    /**
+     * Select field with [name] in [JsObject] and extract as [A] from path.
+     */
+    fun <A> selectExtract(DE: Decoder<A>, EN: Encoder<A>, name: String): Kind4<F, Json, Json, A, A>
+
+    /**
+     * Select every entry in [JsObject] or [JsArray].
+     */
+    fun every(): JsonTraversalPath
+
+    /**
+     * Filter [JsArray] by indices that satisfy the predicate [p].
+     */
+    fun filterIndex(p: Predicate<Int>): JsonTraversalPath
+
+    /**
+     * Filter [JsObject] by keys that satisfy the predicate [p].
+     */
+    fun filterKeys(p: Predicate<String>): JsonTraversalPath
+}

--- a/helios-optics/src/main/kotlin/helios/optics/JsonTraversalPath.kt
+++ b/helios-optics/src/main/kotlin/helios/optics/JsonTraversalPath.kt
@@ -4,101 +4,108 @@ import arrow.core.*
 import arrow.optics.*
 import arrow.optics.typeclasses.*
 import helios.core.*
+import helios.instances.StringDecoderInstance
+import helios.instances.StringEncoderInstance
 import helios.typeclasses.*
 
-data class JsonTraversalPath(val json: Traversal<Json, Json>) {
+data class JsonTraversalPath(override val json: Traversal<Json, Json>): JsonPathFunctions<PTraversal.ForTraversal> {
 
     /**
      * Extract value as [Boolean] from path.
      */
-    val boolean: Traversal<Json, Boolean> = json compose jsonJsBoolean() compose jsBooleanIso()
+    override val boolean: Traversal<Json, Boolean> = json compose jsonJsBoolean() compose jsBooleanIso()
+
+    /**
+     * Extract value as [CharSequence] from path.
+     */
+    override val charseq: Traversal<Json, CharSequence> = json compose jsonJsString() compose  jsStringIso()
 
     /**
      * Extract value as [String] from path.
      */
-    val string: Traversal<Json, CharSequence> = json compose jsonJsString() compose jsStringIso()
+    override val string: Traversal<Json, String> = extract(StringEncoderInstance, StringDecoderInstance)
 
     /**
      * Extract value as [JsNumber] from path.
      */
-    val number: Traversal<Json, JsNumber> = json compose jsonJsNumber()
+    override val number: Traversal<Json, JsNumber> = json compose jsonJsNumber()
 
     /**
      * Extract value as [JsDecimal] from path.
      */
-    val decimal: Traversal<Json, String> = number compose jsNumberJsDecimal() compose jsDecimalIso()
+    override val decimal: Traversal<Json, String> = number compose jsNumberJsDecimal() compose jsDecimalIso()
 
     /**
      * Extract value as [Long] from path.
      */
-    val long: Traversal<Json, Long> = number compose jsNumberJsLong() compose jsLongIso()
+    override val long: Traversal<Json, Long> = number compose jsNumberJsLong() compose jsLongIso()
 
     /**
      * Extract value as [Float] from path.
      */
-    val float: Traversal<Json, Float> = number compose jsNumberJsFloat() compose jsFloatIso()
+    override val float: Traversal<Json, Float> = number compose jsNumberJsFloat() compose jsFloatIso()
 
     /**
      * Extract value as [Int] from path.
      */
-    val int: Traversal<Json, Int> = number compose jsNumberJsInt() compose jsIntIso()
+    override val int: Traversal<Json, Int> = number compose jsNumberJsInt() compose jsIntIso()
 
     /**
      * Extract [JsArray] as `List<Json>` from path.
      */
-    val array: Traversal<Json, List<Json>> = json compose jsonJsArray() compose jsArrayIso()
+    override val array: Traversal<Json, List<Json>> = json compose jsonJsArray() compose jsArrayIso()
 
     /**
      * Extract [JsObject] as `Map<String, Json>` from path.
      */
-    val `object`: Traversal<Json, Map<String, Json>> = json compose jsonJsObject() compose jsObjectIso()
+    override val `object`: Traversal<Json, Map<String, Json>> = json compose jsonJsObject() compose jsObjectIso()
 
     /**
      * Extract [JsNull] from path.
      */
-    val `null`: Traversal<Json, JsNull> = json compose jsonJsNull()
+    override val `null`: Traversal<Json, JsNull> = json compose jsonJsNull()
 
     /**
      * Select field with [name] in [JsObject] from path.
      */
-    fun select(name: String) = JsonTraversalPath(json compose jsonJsObject() compose Index.index(name))
+    override fun select(name: String) = JsonTraversalPath(json compose jsonJsObject() compose index<JsObject, String, Json>().index(name).asHPOptional())
 
     /**
      * Extract field with [name] from [JsObject] from path.
      */
-    fun at(field: String): Traversal<Json, Option<Json>> = json compose jsonJsObject() compose At.at(field)
+    override fun at(field: String): Traversal<Json, Option<Json>> = json compose jsonJsObject() compose At.at(field)
 
     /**
      *  Get element at index [i] from [JsArray].
      */
-    operator fun get(i: Int) = JsonTraversalPath(json compose jsonJsArray() compose Index.index(i))
+    override operator fun get(i: Int) = JsonTraversalPath(json compose jsonJsArray() compose index<JsArray, Int, Json>().index(i).asHPOptional())
 
     /**
      * Extract [A] from path.
      */
-    fun <A> extract(DE: Decoder<A>, EN: Encoder<A>): Traversal<Json, A> =
+    override fun <A> extract(DE: Decoder<A>, EN: Encoder<A>): Traversal<Json, A> =
             json compose parse(DE, EN)
 
     /**
      * Select field with [name] in [JsObject] and extract as [A] from path.
      */
-    fun <A> selectExtract(DE: Decoder<A>, EN: Encoder<A>, name: String): Traversal<Json, A> =
+    override fun <A> selectExtract(DE: Decoder<A>, EN: Encoder<A>, name: String): Traversal<Json, A> =
             select(name).extract(DE, EN)
 
     /**
      * Select every entry in [JsObject] or [JsArray].
      */
-    fun every() = JsonTraversalPath(json compose jsonTraversal)
+    override fun every() = JsonTraversalPath(json compose jsonTraversal)
 
     /**
      * Filter [JsArray] by indices that satisfy the predicate [p].
      */
-    fun filterIndex(p: Predicate<Int>) = JsonTraversalPath(array compose FilterIndex.filterIndex(p = p))
+    override fun filterIndex(p: Predicate<Int>) = JsonTraversalPath(array compose filterIndex<List<Json>, Int, Json>().filter(p).asHPTraversal())
 
     /**
      * Filter [JsObject] by keys that satisfy the predicate [p].
      */
-    fun filterKeys(p: Predicate<String>) = JsonTraversalPath(`object` compose FilterIndex.filterIndex(p = p))
+    override fun filterKeys(p: Predicate<String>) = JsonTraversalPath(`object` compose filterIndex<Map<String, Json>, String, Json>().filter( p).asHPTraversal())
 
 }
 

--- a/helios-optics/src/main/kotlin/helios/optics/Optional.kt
+++ b/helios-optics/src/main/kotlin/helios/optics/Optional.kt
@@ -1,0 +1,277 @@
+package helios.optics
+
+import arrow.*
+import arrow.core.*
+import arrow.optics.Fold
+import arrow.optics.Getter
+import arrow.optics.Iso
+import arrow.optics.PIso
+import arrow.optics.PLens
+import arrow.optics.PPrism
+import arrow.optics.PSetter
+import arrow.typeclasses.Applicative
+import arrow.typeclasses.Monoid
+import arrow.typeclasses.applicative
+
+
+
+inline fun <S, T, A, B> OptionalOf<S, T, A, B>.fix(): POptional<S, T, A, B> = this as POptional<S, T, A, B>
+
+typealias OptionalOf<S, T, A, B>  = Kind4<POptional.ForOptional, S, T, A, B>
+
+/**
+ * [Optional] is a type alias for [POptional] which fixes the type arguments
+ * and restricts the [POptional] to monomorphic updates.
+ */
+typealias Optional<S, A> = POptional<S, S, A, A>
+
+/**
+ * An [Optional] is an optic that allows to see into a structure and getting, setting or modifying an optional focus.
+ *
+ * A (polymorphic) [POptional] is useful when setting or modifying a value for a type with a optional polymorphic focus
+ * i.e. POptional<Ior<Int, Double>, Ior<String, Double>, Int, String>
+ *
+ * A [POptional] can be seen as a weaker [Lens] and [Prism] and combines their weakest functions:
+ * - `set: (S, B) -> T` meaning we can focus into an `S` and set a value `B` for a target `A` and obtain a modified source `T`
+ * - `getOrModify: (S) -> Either<T, A>` meaning it returns the focus of a [POptional] OR the original value
+ *
+ * @param S the source of a [POptional]
+ * @param T the modified source of a [POptional]
+ * @param A the focus of a [POptional]
+ * @param B the modified focus of a [POptional]
+ */
+interface POptional<S, T, A, B> : OptionalOf<S, T, A, B> {
+
+    class ForOptional private constructor()
+
+    /**
+     * Get the modified source of a [POptional]
+     */
+    fun set(s: S, b: B): T
+
+    /**
+     * Get the focus of a [POptional] or return the original value while allowing the type to change if it does not match
+     */
+    fun getOrModify(s: S): Either<T, A>
+
+    companion object {
+
+        fun <S> id() = Iso.id<S>().asOptional().asHPOptional()
+
+        /**
+         * [POptional] that takes either [S] or [S] and strips the choice of [S].
+         */
+        fun <S> codiagonal(): Optional<Either<S, S>, S> = Optional(
+                { it.fold({ Either.Right(it) }, { Either.Right(it) }) },
+                { a -> { aa -> aa.bimap({ a }, { a }) } }
+        )
+
+        /**
+         * Invoke operator overload to create a [POptional] of type `S` with focus `A`.
+         * Can also be used to construct [Optional]
+         */
+        operator fun <S, T, A, B> invoke(getOrModify: (S) -> Either<T, A>, set: (B) -> (S) -> T): POptional<S, T, A, B> = object : POptional<S, T, A, B> {
+            override fun getOrModify(s: S): Either<T, A> = getOrModify(s)
+
+            override fun set(s: S, b: B): T = set(b)(s)
+        }
+
+        /**
+         * Invoke operator overload to create a [POptional] of type `S` with focus `A`.
+         * Can also be used to construct [Optional]
+         */
+        operator fun <S, A> invoke(partialFunction: PartialFunction<S, A>, set: (A) -> (S) -> S): Optional<S, A> = Optional(
+                getOrModify = { s -> partialFunction.lift()(s).fold({ Either.Left(s) }, { Either.Right(it) }) },
+                set = set
+        )
+
+        /**
+         * [POptional] that never sees its focus
+         */
+        fun <A, B> void(): Optional<A, B> = Optional(
+                { Either.Left(it) },
+                { _ -> ::identity }
+        )
+
+    }
+
+    /**
+     * Modify the focus of a [POptional] with an Applicative function [f]
+     */
+    fun <F> modifyF(FA: Applicative<F>, s: S, f: (A) -> Kind<F, B>): Kind<F, T> = getOrModify(s).fold(
+            FA::pure,
+            { FA.map(f(it), { set(s, it) }) }
+    )
+
+    /**
+     * Lift a function [f]: `(A) -> Kind<F, B> to the context of `S`: `(S) -> Kind<F, T>`
+     */
+    fun <F> liftF(FA: Applicative<F>, f: (A) -> Kind<F, B>): (S) -> Kind<F, T> = { s ->
+        modifyF(FA, s, f)
+    }
+
+    /**
+     * Get the focus of a [POptional] or [Option.None] if the is not there
+     */
+    fun getOption(a: S): Option<A> = getOrModify(a).toOption()
+
+    /**
+     * Set the focus of a [POptional] with a value.
+     * @return [Option.None] if the [POptional] is not matching
+     */
+    fun setOption(s: S, b: B): Option<T> = modifiyOption(s) { b }
+
+    /**
+     * Check if there is no focus
+     */
+    fun isEmpty(s: S): Boolean = !nonEmpty(s)
+
+    /**
+     * Check if there is a focus
+     */
+    fun nonEmpty(s: S): Boolean = getOption(s).fold({ false }, { true })
+
+    /**
+     * Join two [POptional] with the same focus [B]
+     */
+    infix fun <S1, T1> choice(other: POptional<S1, T1, A, B>): POptional<Either<S, S1>, Either<T, T1>, A, B> =
+            POptional(
+                    { ss -> ss.fold({ getOrModify(it).bimap({ Either.Left(it) }, ::identity) }, { other.getOrModify(it).bimap({ Either.Right(it) }, ::identity) }) },
+                    { b -> { it.bimap({ s -> this.set(s, b) }, { s -> other.set(s, b) }) } }
+            )
+
+    /**
+     * Create a product of the [POptional] and a type [C]
+     */
+    fun <C> first(): POptional<Tuple2<S, C>, Tuple2<T, C>, Tuple2<A, C>, Tuple2<B, C>> =
+            POptional(
+                    { (s, c) -> getOrModify(s).bimap({ it toT c }, { it toT c }) },
+                    { (b, c) -> { (s, c2) -> setOption(s, b).fold({ set(s, b) toT c2 }, { it toT c }) } }
+            )
+
+    /**
+     * Create a product of a type [C] and the [POptional]
+     */
+    fun <C> second(): POptional<Tuple2<C, S>, Tuple2<C, T>, Tuple2<C, A>, Tuple2<C, B>> =
+            POptional(
+                    { (c, s) -> getOrModify(s).bimap({ c toT it }, { c toT it }) },
+                    { (c, b) -> { (c2, s) -> setOption(s, b).fold({ c2 toT set(s, b) }, { c toT it }) } }
+            )
+
+    /**
+     * Compose a [POptional] with a [POptional]
+     */
+    infix fun <C, D> compose(other: POptional<A, B, C, D>): POptional<S, T, C, D> = POptional(
+            { s -> getOrModify(s).flatMap { a -> other.getOrModify(a).bimap({ set(s, it) }, ::identity) } },
+            { d -> { s -> modify(s) { a -> other.set(a, d) } } }
+    )
+
+    /**
+     * Compose a [POptional] with a [PTraversal]
+     */
+    infix fun <C, D> compose(other: PTraversal<A, B, C, D>): PTraversal<S, T, C, D> = asTraversal() compose other
+
+    /**
+     * Compose a [POptional] with a [PPrism]
+     */
+    infix fun <C, D> compose(other: PPrism<A, B, C, D>): POptional<S, T, C, D> = compose(POptional(
+            other::getOrModify,
+            { b -> { s -> other.set(s, b) } }
+    ))
+
+    /**
+     * Compose a [POptional] with a [PLens]
+     */
+    infix fun <C, D> compose(other: PLens<A, B, C, D>): POptional<S, T, C, D> = compose(POptional(
+            { s -> Either.Right(other.get(s)) },
+            { b -> { s -> other.set(s, b) } }
+    ))
+
+    /**
+     * Compose a [POptional] with a [PIso]
+     */
+    infix fun <C, D> compose(other: PIso<A, B, C, D>): POptional<S, T, C, D> = compose(POptional(
+            { s -> Either.Right(other.get(s)) },
+            { b -> { _ -> other.set(b) } }
+    ))
+
+    /**
+     * Compose a [POptional] with a [PIso]
+     */
+    infix fun <C, D> compose(other: PSetter<A, B, C, D>): PSetter<S, T, C, D> = asSetter() compose other
+
+    /**
+     * Compose a [POptional] with a [Fold]
+     */
+    infix fun <C> compose(other: Fold<A, C>): Fold<S, C> = asFold() compose other
+
+    /**
+     * Compose a [POptional] with a [Fold]
+     */
+    infix fun <C> compose(other: Getter<A, C>): Fold<S, C> = asFold() compose other
+
+
+    /**
+     * View a [POptional] as a [PSetter]
+     */
+    fun asSetter(): PSetter<S, T, A, B> = PSetter { f -> { s -> modify(s, f) } }
+
+    /**
+     * View a [POptional] as a [Fold]
+     */
+    fun asFold() = object : Fold<S, A> {
+        override fun <R> foldMap(M: Monoid<R>, s: S, f: (A) -> R): R = getOption(s).map(f).getOrElse(M::empty)
+    }
+
+    /**
+     * View a [POptional] as a [PTraversal]
+     */
+    fun asTraversal(): PTraversal<S, T, A, B> = object : PTraversal<S, T, A, B> {
+        override fun <F> modifyF(FA: Applicative<F>, s: S, f: (A) -> Kind<F, B>): Kind<F, T> =
+                this@POptional.modifyF(FA, s, f)
+    }
+
+}
+
+/**
+ * Modify the focus of a [POptional] with a function [f]
+ */
+inline fun <S, T, A, B> POptional<S, T, A, B>.modify(s: S, crossinline f: (A) -> B): T = getOrModify(s).fold(::identity, { a -> set(s, f(a)) })
+
+/**
+ * Lift a function [f]: `(A) -> B to the context of `S`: `(S) -> T`
+ */
+inline fun <S, T, A, B> POptional<S, T, A, B>.lift(crossinline f: (A) -> B): (S) -> T = { s -> modify(s, f) }
+
+/**
+ * Modify the focus of a [POptional] with an [Applicative] function [f]
+ */
+inline fun <S, T, A, B, reified F> POptional<S, T, A, B>.modifyF(s: S, crossinline f: (A) -> Kind<F, B>, FA: Applicative<F> = applicative()): Kind<F, T> =
+        modifyF(FA, s) { a -> f(a) }
+
+/**
+ * Lift a function [f]: `(A) -> Kind<F, B> to the context of `S`: `(S) -> Kind<F, T>` with an [Applicative] function [f]
+ */
+inline fun <S, T, A, B, reified F> POptional<S, T, A, B>.liftF(crossinline f: (A) -> Kind<F, B>, FA: Applicative<F> = applicative()): (S) -> Kind<F, T> = liftF(FA) { a -> f(a) }
+
+/**
+ * Modify the focus of a [POptional] with a function [f]
+ * @return [Option.None] if the [POptional] is not matching
+ */
+inline fun <S, T, A, B> POptional<S, T, A, B>.modifiyOption(s: S, crossinline f: (A) -> B): Option<T> = getOption(s).map({ set(s, f(it)) })
+
+/**
+ * Find the focus that satisfies the predicate [p]
+ */
+inline fun <S, T, A, B> POptional<S, T, A, B>.find(s: S, crossinline p: (A) -> Boolean): Option<A> =
+        getOption(s).flatMap { b -> if (p(b)) Some(b) else None }
+
+/**
+ * Check if there is a focus and it satisfies the predicate [p]
+ */
+inline fun <S, T, A, B> POptional<S, T, A, B>.exists(s: S, crossinline p: (A) -> Boolean): Boolean = getOption(s).fold({ false }, p)
+
+/**
+ * Check if there is no focus or the target satisfies the predicate [p]
+ */
+inline fun <S, T, A, B> POptional<S, T, A, B>.all(s: S, crossinline p: (A) -> Boolean): Boolean = getOption(s).fold({ true }, p)

--- a/helios-optics/src/main/kotlin/helios/optics/Traversal.kt
+++ b/helios-optics/src/main/kotlin/helios/optics/Traversal.kt
@@ -1,0 +1,415 @@
+package helios.optics
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.core.Id
+import arrow.core.None
+import arrow.core.Option
+import arrow.core.Some
+import arrow.core.applicative
+import arrow.core.identity
+import arrow.core.value
+import arrow.data.Const
+import arrow.data.ListK
+import arrow.data.applicative
+import arrow.data.monoid
+import arrow.data.value
+import arrow.instances.IntMonoid
+import arrow.optics.Fold
+import arrow.optics.Iso
+import arrow.optics.PIso
+import arrow.optics.PLens
+import arrow.optics.PPrism
+import arrow.optics.PSetter
+import arrow.syntax.applicative.map
+import arrow.typeclasses.Applicative
+import arrow.typeclasses.Monoid
+import arrow.typeclasses.Traverse
+import arrow.typeclasses.applicative
+import arrow.typeclasses.monoid
+import arrow.typeclasses.traverse
+
+inline fun <S, T, A, B> TraversalOf<S, T, A, B>.fix(): PTraversal<S, T, A, B> = this as PTraversal<S, T, A, B>
+
+typealias TraversalOf<S, T, A, B>  = Kind4<PTraversal.ForTraversal, S, T, A, B>
+
+/**
+ * [Traversal] is a type alias for [PTraversal] which fixes the type arguments
+ * and restricts the [PTraversal] to monomorphic updates.
+ */
+typealias Traversal<S, A> = PTraversal<S, S, A, A>
+
+/**
+ * A [Traversal] is an optic that allows to see into a structure with 0 to N foci.
+ *
+ * [Traversal] is a generalisation of [arrow.Traverse] and can be seen as a representation of modifyF.
+ * all methods are written in terms of modifyF
+ *
+ * @param S the source of a [PTraversal]
+ * @param T the modified source of a [PTraversal]
+ * @param A the target of a [PTraversal]
+ * @param B the modified target of a [PTraversal]
+ */
+interface PTraversal<S, T, A, B> : TraversalOf<S, T, A, B> {
+
+    class ForTraversal private constructor()
+
+    fun <F> modifyF(FA: Applicative<F>, s: S, f: (A) -> Kind<F, B>): Kind<F, T>
+
+    companion object {
+        fun <S> id() = Iso.id<S>().asTraversal()
+
+        fun <S> codiagonal(): Traversal<Either<S, S>, S> = object : Traversal<Either<S, S>, S> {
+            override fun <F> modifyF(FA: Applicative<F>, s: Either<S, S>, f: (S) -> Kind<F, S>): Kind<F, Either<S, S>> =
+                    s.bimap(f, f).fold({ fa -> FA.map(fa, { a -> Either.Left(a) }) }, { fa -> FA.map(fa, { a -> Either.Right(a) }) })
+        }
+
+        /**
+         * Construct a [PTraversal] from a [Traverse] instance.
+         */
+        fun <T, A, B> fromTraversable(TT: Traverse<T>) = object : PTraversal<Kind<T, A>, Kind<T, B>, A, B> {
+            override fun <F> modifyF(FA: Applicative<F>, s: Kind<T, A>, f: (A) -> Kind<F, B>): Kind<F, Kind<T, B>> =
+                    TT.traverse(s, f, FA)
+        }
+
+        /**
+         * [PTraversal] that points to nothing
+         */
+        fun <S, A> void() = Optional.void<S, A>().asTraversal()
+
+        /**
+         * [PTraversal] constructor from multiple getters of the same source.
+         */
+        operator fun <S, T, A, B> invoke(get1: (S) -> A, get2: (S) -> A, set: (B, B, S) -> T): PTraversal<S, T, A, B> = object : PTraversal<S, T, A, B> {
+            override fun <F> modifyF(FA: Applicative<F>, s: S, f: (A) -> Kind<F, B>): Kind<F, T> =
+                    FA.map(
+                            f(get1(s)), f(get2(s)),
+                            { (b1, b2) -> set(b1, b2, s) }
+                    )
+        }
+
+        operator fun <S, T, A, B> invoke(
+                get1: (S) -> A,
+                get2: (S) -> A,
+                get3: (S) -> A,
+                set: (B, B, B, S) -> T): PTraversal<S, T, A, B> = object : PTraversal<S, T, A, B> {
+            override fun <F> modifyF(FA: Applicative<F>, s: S, f: (A) -> Kind<F, B>): Kind<F, T> =
+                    FA.map(
+                            f(get1(s)), f(get2(s)), f(get3(s)),
+                            { (b1, b2, b3) -> set(b1, b2, b3, s) }
+                    )
+        }
+
+        operator fun <S, T, A, B> invoke(
+                get1: (S) -> A,
+                get2: (S) -> A,
+                get3: (S) -> A,
+                get4: (S) -> A,
+                set: (B, B, B, B, S) -> T): PTraversal<S, T, A, B> = object : PTraversal<S, T, A, B> {
+            override fun <F> modifyF(FA: Applicative<F>, s: S, f: (A) -> Kind<F, B>): Kind<F, T> =
+                    FA.map(
+                            f(get1(s)), f(get2(s)), f(get3(s)), f(get4(s)),
+                            { (b1, b2, b3, b4) -> set(b1, b2, b3, b4, s) }
+                    )
+        }
+
+        operator fun <S, T, A, B> invoke(
+                get1: (S) -> A,
+                get2: (S) -> A,
+                get3: (S) -> A,
+                get4: (S) -> A,
+                get5: (S) -> A,
+                set: (B, B, B, B, B, S) -> T): PTraversal<S, T, A, B> = object : PTraversal<S, T, A, B> {
+            override fun <F> modifyF(FA: Applicative<F>, s: S, f: (A) -> Kind<F, B>): Kind<F, T> =
+                    FA.map(
+                            f(get1(s)), f(get2(s)), f(get3(s)), f(get4(s)), f(get5(s)),
+                            { (b1, b2, b3, b4, b5) -> set(b1, b2, b3, b4, b5, s) }
+                    )
+        }
+
+        operator fun <S, T, A, B> invoke(
+                get1: (S) -> A,
+                get2: (S) -> A,
+                get3: (S) -> A,
+                get4: (S) -> A,
+                get5: (S) -> A,
+                get6: (S) -> A,
+                set: (B, B, B, B, B, B, S) -> T): PTraversal<S, T, A, B> = object : PTraversal<S, T, A, B> {
+            override fun <F> modifyF(FA: Applicative<F>, s: S, f: (A) -> Kind<F, B>): Kind<F, T> =
+                    FA.map(
+                            f(get1(s)), f(get2(s)), f(get3(s)), f(get4(s)), f(get5(s)), f(get6(s)),
+                            { (b1, b2, b3, b4, b5, b6) -> set(b1, b2, b3, b4, b5, b6, s) }
+                    )
+        }
+
+        operator fun <S, T, A, B> invoke(
+                get1: (S) -> A,
+                get2: (S) -> A,
+                get3: (S) -> A,
+                get4: (S) -> A,
+                get5: (S) -> A,
+                get6: (S) -> A,
+                get7: (S) -> A,
+                set: (B, B, B, B, B, B, B, S) -> T): PTraversal<S, T, A, B> = object : PTraversal<S, T, A, B> {
+            override fun <F> modifyF(FA: Applicative<F>, s: S, f: (A) -> Kind<F, B>): Kind<F, T> =
+                    FA.map(
+                            f(get1(s)), f(get2(s)), f(get3(s)), f(get4(s)), f(get5(s)), f(get6(s)), f(get7(s)),
+                            { (b1, b2, b3, b4, b5, b6, b7) -> set(b1, b2, b3, b4, b5, b6, b7, s) }
+                    )
+        }
+
+        operator fun <S, T, A, B> invoke(
+                get1: (S) -> A,
+                get2: (S) -> A,
+                get3: (S) -> A,
+                get4: (S) -> A,
+                get5: (S) -> A,
+                get6: (S) -> A,
+                get7: (S) -> A,
+                get8: (S) -> A,
+                set: (B, B, B, B, B, B, B, B, S) -> T): PTraversal<S, T, A, B> = object : PTraversal<S, T, A, B> {
+            override fun <F> modifyF(FA: Applicative<F>, s: S, f: (A) -> Kind<F, B>): Kind<F, T> =
+                    FA.map(
+                            f(get1(s)), f(get2(s)), f(get3(s)), f(get4(s)), f(get5(s)), f(get6(s)), f(get7(s)), f(get8(s)),
+                            { (b1, b2, b3, b4, b5, b6, b7, b8) -> set(b1, b2, b3, b4, b5, b6, b7, b8, s) }
+                    )
+        }
+
+        operator fun <S, T, A, B> invoke(
+                get1: (S) -> A,
+                get2: (S) -> A,
+                get3: (S) -> A,
+                get4: (S) -> A,
+                get5: (S) -> A,
+                get6: (S) -> A,
+                get7: (S) -> A,
+                get8: (S) -> A,
+                get9: (S) -> A,
+                set: (B, B, B, B, B, B, B, B, B, S) -> T): PTraversal<S, T, A, B> = object : PTraversal<S, T, A, B> {
+            override fun <F> modifyF(FA: Applicative<F>, s: S, f: (A) -> Kind<F, B>): Kind<F, T> =
+                    FA.map(
+                            f(get1(s)), f(get2(s)), f(get3(s)), f(get4(s)), f(get5(s)), f(get6(s)), f(get7(s)), f(get8(s)), f(get9(s)),
+                            { (b1, b2, b3, b4, b5, b6, b7, b8, b9) -> set(b1, b2, b3, b4, b5, b6, b7, b8, b9, s) }
+                    )
+        }
+
+        operator fun <S, T, A, B> invoke(
+                get1: (S) -> A,
+                get2: (S) -> A,
+                get3: (S) -> A,
+                get4: (S) -> A,
+                get5: (S) -> A,
+                get6: (S) -> A,
+                get7: (S) -> A,
+                get8: (S) -> A,
+                get9: (S) -> A,
+                get10: (S) -> A,
+                set: (B, B, B, B, B, B, B, B, B, B, S) -> T): PTraversal<S, T, A, B> = object : PTraversal<S, T, A, B> {
+            override fun <F> modifyF(FA: Applicative<F>, s: S, f: (A) -> Kind<F, B>): Kind<F, T> =
+                    FA.map(
+                            f(get1(s)), f(get2(s)), f(get3(s)), f(get4(s)), f(get5(s)), f(get6(s)), f(get7(s)), f(get8(s)), f(get9(s)), f(get10(s)),
+                            { (b1, b2, b3, b4, b5, b6, b7, b8, b9, b10) -> set(b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, s) }
+                    )
+        }
+
+    }
+
+    /**
+     * Map each target to a Monoid and combine the results
+     */
+    fun <R> foldMap(M: Monoid<R>, s: S, f: (A) -> R): R =
+            modifyF(Const.applicative(M, Unit), s, { b -> Const(f(b)) }).value()
+
+    /**
+     * Fold using the given [Monoid] instance.
+     */
+    fun fold(M: Monoid<A>, s: S): A = foldMap(M, s, ::identity)
+
+    /**
+     * Alias for fold.
+     */
+    fun combineAll(M: Monoid<A>, s: S): A = fold(M, s)
+
+    /**
+     * Get all foci of the [PTraversal]
+     */
+    fun getAll(s: S): ListK<A> = foldMap(ListK.monoid(), s, { ListK(listOf(it)) })
+
+    /**
+     * Set polymorphically the target of a [PTraversal] with a value
+     */
+    fun set(s: S, b: B): T = modify(s) { b }
+
+    /**
+     * Calculate the number of targets in the [PTraversal]
+     */
+    fun size(s: S): Int = foldMap(IntMonoid, s, { 1 })
+
+    /**
+     * Check if there is no target
+     */
+    fun isEmpty(s: S): Boolean = foldMap(AndMonoid, s, { _ -> false })
+
+    /**
+     * Check if there is at least one target
+     */
+    fun nonEmpty(s: S): Boolean = !isEmpty(s)
+
+    /**
+     * Find the first target or [Option.None] if no targets
+     */
+    fun headOption(s: S): Option<A> = foldMap(firstOptionMonoid<A>(), s, { b -> Const(Some(b)) }).value
+
+    /**
+     * Find the first target or [Option.None] if no targets
+     */
+    fun lastOption(s: S): Option<A> = foldMap(lastOptionMonoid<A>(), s, { b -> Const(Some(b)) }).value
+
+    fun <U, V> choice(other: PTraversal<U, V, A, B>): PTraversal<Either<S, U>, Either<T, V>, A, B> = object : PTraversal<Either<S, U>, Either<T, V>, A, B> {
+        override fun <F> modifyF(FA: Applicative<F>, s: Either<S, U>, f: (A) -> Kind<F, B>): Kind<F, Either<T, V>> = s.fold(
+                { a -> FA.map(this@PTraversal.modifyF(FA, a, f)) { Either.Left(it) } },
+                { u -> FA.map(other.modifyF(FA, u, f)) { Either.Right(it) } }
+        )
+    }
+
+    /**
+     * Compose a [PTraversal] with a [PTraversal]
+     */
+    infix fun <C, D> compose(other: PTraversal<A, B, C, D>): PTraversal<S, T, C, D> = object : PTraversal<S, T, C, D> {
+        override fun <F> modifyF(FA: Applicative<F>, s: S, f: (C) -> Kind<F, D>): Kind<F, T> =
+                this@PTraversal.modifyF(FA, s, { b -> other.modifyF(FA, b, f) })
+    }
+
+    /**
+     * Compose a [PTraversal] with a [PSetter]
+     */
+    infix fun <C, D> compose(other: PSetter<A, B, C, D>): PSetter<S, T, C, D> = asSetter() compose other
+
+    /**
+     * Compose a [PTraversal] with a [POptional]
+     */
+    infix fun <C, D> compose(other: POptional<A, B, C, D>): PTraversal<S, T, C, D> = compose(other.asTraversal())
+
+    /**
+     * Compose a [PTraversal] with a [PLens]
+     */
+    infix fun <C, D> compose(other: PLens<A, B, C, D>): PTraversal<S, T, C, D> = compose(object : PTraversal<A, B, C, D> {
+        override fun <F> modifyF(FA: Applicative<F>, s: A, f: (C) -> Kind<F, D>): Kind<F, B> =
+                FA.map(f(other.get(s)), { b -> other.set(s, b) })
+    })
+
+    /**
+     * Compose a [PTraversal] with a [PPrism]
+     */
+    infix fun <C, D> compose(other: PPrism<A, B, C, D>): PTraversal<S, T, C, D> = compose(object : PTraversal<A, B, C, D> {
+        override fun <F> modifyF(FA: Applicative<F>, s: A, f: (C) -> Kind<F, D>): Kind<F, B> = other.getOrModify(s).fold(
+                FA::pure,
+                { FA.map(f(it), other::reverseGet) }
+        )
+    })
+
+    /**
+     * Compose a [PTraversal] with a [PIso]
+     */
+    infix fun <C, D> compose(other: PIso<A, B, C, D>): PTraversal<S, T, C, D> = compose(object : PTraversal<A, B, C, D> {
+        override fun <F> modifyF(FA: Applicative<F>, s: A, f: (C) -> Kind<F, D>): Kind<F, B> =
+        FA.map(f(other.get(s)), other::reverseGet)
+    })
+
+    /**
+     * Compose a [PTraversal] with a [Fold]
+     */
+    infix fun <C> compose(other: Fold<A, C>): Fold<S, C> = asFold() compose other
+
+    /**
+     * Plus operator overload to compose [PTraversal] with other optics
+     */
+    operator fun <C, D> plus(other: PTraversal<A, B, C, D>): PTraversal<S, T, C, D> = compose(other)
+
+    operator fun <C, D> plus(other: POptional<A, B, C, D>): PTraversal<S, T, C, D> = compose(other)
+
+    fun asSetter(): PSetter<S, T, A, B> = PSetter { f -> { s -> modify(s, f) } }
+
+    fun asFold(): Fold<S, A> = object : Fold<S, A> {
+        override fun <R> foldMap(M: Monoid<R>, s: S, f: (A) -> R): R =
+                this@PTraversal.foldMap(M, s, f)
+    }
+
+}
+
+/**
+ * Construct a [PTraversal] from a [Traverse] instance.
+ */
+inline fun <reified T, A, B> PTraversal.Companion.fromTraversable(TT: Traverse<T> = traverse(), dummy: Unit = Unit) = PTraversal.Companion.fromTraversable<T, A, B>(TT)
+/**
+ * Modify polymorphically the target of a [PTraversal] with an Applicative function
+ */
+inline fun <S, T, A, B, reified F> PTraversal<S, T, A, B>.modifyF(s: S, crossinline f: (A) -> Kind<F, B>, AF: Applicative<F> = applicative()): Kind<F, T> =
+        modifyF(AF, s) { a -> f(a) }
+
+/**
+ * Find the first target matching the predicate
+ */
+inline fun <S, T, A, B> PTraversal<S, T, A, B>.find(s: S, crossinline p: (A) -> Boolean): Option<A> = foldMap(firstOptionMonoid<A>(), s, { a ->
+    if (p(a)) Const(Some(a))
+    else Const(None)
+}).value
+
+/**
+ * Map each target to a Monoid and combine the results
+ */
+inline fun <S, T, A, B, reified R> PTraversal<S, T, A, B>.foldMap(s: S, crossinline f: (A) -> R, M: Monoid<R> = monoid()): R =
+        modifyF(Const.applicative(M), s, { b -> Const(f(b)) }).value()
+
+/**
+ * Modify polymorphically the target of a [PTraversal] with a function [f]
+ */
+inline fun <S, T, A, B> PTraversal<S, T, A, B>.modify(s: S, crossinline f: (A) -> B): T = modifyF(Id.applicative(), s, { b -> Id(f(b)) }).value()
+
+/**
+ * Check whether at least one element satisfies the predicate.
+ *
+ * If there are no elements, the result is false.
+ */
+inline fun <S, T, A, B> PTraversal<S, T, A, B>.exist(s: S, crossinline p: (A) -> Boolean): Boolean = find(s, p).fold({ false }, { true })
+
+/**
+ * Check if forall targets satisfy the predicate
+ */
+inline fun <S, T, A, B> PTraversal<S, T, A, B>.forall(s: S, crossinline p: (A) -> Boolean): Boolean = foldMap(s, p, AndMonoid)
+
+/**
+ * Fold using the given [Monoid] instance.
+ */
+inline fun <S, T, reified A, B> PTraversal<S, T, A, B>.fold(s: S, M: Monoid<A> = monoid()): A = foldMap(s, ::identity, M)
+
+/**
+ * Alias for fold.
+ */
+inline fun <S, T, reified A, B> PTraversal<S, T, A, B>.combineAll(s: S, M: Monoid<A> = monoid()): A = fold(s, M)
+
+object AndMonoid : Monoid<Boolean> {
+    override fun combine(a: Boolean, b: Boolean): Boolean = a && b
+    override fun empty(): Boolean = true
+}
+
+sealed class First
+sealed class Last
+
+fun <A> firstOptionMonoid() = object : Monoid<Const<Option<A>, First>> {
+
+    override fun empty() = Const<Option<A>, First>(None)
+
+    override fun combine(a: Const<Option<A>, First>, b: Const<Option<A>, First>) =
+            if (a.value.fold({ false }, { true })) a else b
+
+}
+
+fun <A> lastOptionMonoid() = object : Monoid<Const<Option<A>, Last>> {
+
+    override fun empty() = Const<Option<A>, Last>(None)
+
+    override fun combine(a: Const<Option<A>, Last>, b: Const<Option<A>, Last>) =
+            if (b.value.fold({ false }, { true })) b else a
+
+}

--- a/helios-optics/src/main/kotlin/helios/optics/predef.kt
+++ b/helios-optics/src/main/kotlin/helios/optics/predef.kt
@@ -1,8 +1,8 @@
 package helios.optics
 
 import arrow.Kind
+import arrow.Kind3
 import arrow.core.identity
-import arrow.optics.Traversal
 import arrow.optics.typeclasses.each
 import arrow.typeclasses.Applicative
 import helios.core.JsArray
@@ -22,4 +22,16 @@ val jsonTraversal = object : Traversal<Json, Json> {
             { FA.pure(it) },
             { FA.pure(JsNull) }
     )
+}
+
+typealias Kind4<F, A, B, C, D> = Kind<Kind3<F, A, B, C>, D>
+
+fun <S, T, A, B> arrow.optics.POptional<S, T, A, B>.asHPOptional(): POptional<S, T, A, B> = POptional(
+        getOrModify = this::getOrModify,
+        set = { b -> { s -> this.set(s, b) } }
+)
+
+fun <S, T, A, B> arrow.optics.PTraversal<S, T, A, B>.asHPTraversal() = object : PTraversal<S, T, A, B> {
+    override fun <F> modifyF(FA: Applicative<F>, s: S, f: (A) -> Kind<F, B>): Kind<F, T> =
+            this@asHPTraversal.modifyF(FA, s, f)
 }

--- a/helios-optics/src/test/kotlin/helios/optics/JsonDSLTest.kt
+++ b/helios-optics/src/test/kotlin/helios/optics/JsonDSLTest.kt
@@ -19,6 +19,7 @@ import helios.core.JsObject
 import helios.core.JsString
 import helios.optics.JsonPath.Companion.root
 import helios.typeclasses.decoder
+import helios.typeclasses.encoder
 
 import io.kotlintest.KTestJUnitRunner
 import io.kotlintest.matchers.shouldBe
@@ -42,105 +43,105 @@ class JsonDSLTest : UnitSpec() {
 
         "bool prism" {
             forAll(genJsBoolean()) { jsBool ->
-                JsonPath.root.boolean.getOption(jsBool) == jsBool.value.some()
+                JsonPath.root.boolean.fix().getOption(jsBool) == jsBool.value.some()
             }
 
-            JsonPath.root.boolean.getOption(JsString("false")) shouldBe none<Boolean>()
+            JsonPath.root.boolean.fix().getOption(JsString("false")) shouldBe none<Boolean>()
         }
 
         "string prism" {
             forAll(genJsString()) { jsString ->
-                JsonPath.root.string.getOption(jsString) == jsString.value.some()
+                JsonPath.root.string.fix().getOption(jsString) == jsString.value.some()
             }
 
-            JsonPath.root.string.getOption(JsFalse) shouldBe none<String>()
+            JsonPath.root.string.fix().getOption(JsFalse) shouldBe none<String>()
         }
 
         "number prism" {
             forAll(genJsNumber()) { jsNumber ->
-                JsonPath.root.number.getOption(jsNumber) == jsNumber.some()
+                JsonPath.root.number.fix().getOption(jsNumber) == jsNumber.some()
             }
 
-            JsonPath.root.number.getOption(JsFalse) shouldBe none<JsNumber>()
+            JsonPath.root.number.fix().getOption(JsFalse) shouldBe none<JsNumber>()
         }
 
         "decimal prism" {
             forAll(genJsDecimal()) { jsDecimal ->
-                JsonPath.root.decimal.getOption(jsDecimal) == jsDecimal.value.some()
+                JsonPath.root.decimal.fix().getOption(jsDecimal) == jsDecimal.value.some()
             }
 
-            JsonPath.root.decimal.getOption(JsFalse) shouldBe none<JsDecimal>()
+            JsonPath.root.decimal.fix().getOption(JsFalse) shouldBe none<JsDecimal>()
         }
 
         "long prism" {
             forAll(genJsLong()) { jsLong ->
-                JsonPath.root.long.getOption(jsLong) == jsLong.value.some()
+                JsonPath.root.long.fix().getOption(jsLong) == jsLong.value.some()
             }
 
-            JsonPath.root.long.getOption(JsFalse) shouldBe none<JsLong>()
+            JsonPath.root.long.fix().getOption(JsFalse) shouldBe none<JsLong>()
         }
 
         "float prism" {
             forAll(genJsFloat()) { jsFloat ->
-                JsonPath.root.float.getOption(jsFloat) == jsFloat.value.some()
+                JsonPath.root.float.fix().getOption(jsFloat) == jsFloat.value.some()
             }
 
-            JsonPath.root.float.getOption(JsFalse) shouldBe none<JsFloat>()
+            JsonPath.root.float.fix().getOption(JsFalse) shouldBe none<JsFloat>()
         }
 
         "int prism" {
             forAll(genJsInt()) { jsInt ->
-                JsonPath.root.int.getOption(jsInt) == jsInt.value.some()
+                JsonPath.root.int.fix().getOption(jsInt) == jsInt.value.some()
             }
 
-            JsonPath.root.int.getOption(JsString("5")) shouldBe none<Int>()
+            JsonPath.root.int.fix().getOption(JsString("5")) shouldBe none<Int>()
         }
 
         "array prism" {
             forAll(genJsArray()) { jsArray ->
-                JsonPath.root.array.getOption(jsArray) == jsArray.value.some()
+                JsonPath.root.array.fix().getOption(jsArray) == jsArray.value.some()
             }
 
-            JsonPath.root.array.getOption(JsString("5")) shouldBe none<JsArray>()
+            JsonPath.root.array.fix().getOption(JsString("5")) shouldBe none<JsArray>()
         }
 
         "object prism" {
             forAll(genJsObject()) { jsObj ->
-                JsonPath.root.`object`.getOption(jsObj) == jsObj.value.some()
+                JsonPath.root.`object`.fix().getOption(jsObj) == jsObj.value.some()
             }
 
-            JsonPath.root.`object`.getOption(JsString("5")) shouldBe none<JsObject>()
+            JsonPath.root.`object`.fix().getOption(JsString("5")) shouldBe none<JsObject>()
         }
 
         "null prism" {
             forAll(genJsNull()) { jsNull ->
-                JsonPath.root.`null`.getOption(jsNull) == jsNull.some()
+                JsonPath.root.`null`.fix().getOption(jsNull) == jsNull.some()
             }
 
-            JsonPath.root.`null`.getOption(JsString("5")) shouldBe none<JsNull>()
+            JsonPath.root.`null`.fix().getOption(JsString("5")) shouldBe none<JsNull>()
         }
 
         "at from object" {
             forAll(genJson(genCity())) { cityJson ->
-                root.at("streets").getOption(cityJson).flatten() == cityJson["streets"]
+                root.at("streets").fix().getOption(cityJson).flatten() == cityJson["streets"]
             }
         }
 
         "select from object" {
             forAll(genJson(genCity())) { cityJson ->
-                root.select("streets").json.getOption(cityJson) == cityJson["streets"]
+                root.select("streets").json.fix().getOption(cityJson) == cityJson["streets"]
             }
         }
 
         "extract from object" {
             forAll(genJson(genCity())) { cityJson ->
-                root.extract<City>().getOption(cityJson) == decoder<City>().decode(cityJson).toOption()
+                JsonPath.root.extract<City>(decoder(), encoder()).fix().getOption(cityJson) == decoder<City>().decode(cityJson).toOption()
             }
         }
 
         "get from array" {
             forAll(genJson(genCity())) { cityJson ->
-                JsonPath.root.select("streets")[0].extract<Street>().getOption(cityJson) ==
+                JsonPath.root.select("streets")[0].extract<Street>(decoder(), encoder()).fix().getOption(cityJson) ==
                         decoder<City>().decode(cityJson).toOption().flatMap { Option.fromNullable(it.streets.getOrNull(0)) }
             }
         }

--- a/helios-optics/src/test/kotlin/helios/optics/instances.kt
+++ b/helios-optics/src/test/kotlin/helios/optics/instances.kt
@@ -5,6 +5,7 @@ import arrow.core.Option
 import arrow.core.orElse
 import arrow.optics.typeclasses.at
 import arrow.optics.typeclasses.each
+import arrow.optics.typeclasses.filterIndex
 import arrow.optics.typeclasses.index
 import arrow.test.UnitSpec
 import arrow.test.generators.genFunctionAToB
@@ -32,6 +33,7 @@ class InstancesTest : UnitSpec() {
             index<JsArray, Int, Json>().index(1) shouldNotBe null
             each<JsObject, Json>().each() shouldNotBe null
             each<JsArray, Json>().each() shouldNotBe null
+            filterIndex<List<Json>, Int, Json>() shouldNotBe null
             at<JsObject, String, Option<Json>>().at("one") shouldNotBe null
         }
 

--- a/helios-sample/src/main/kotlin/helios/sample/sample.kt
+++ b/helios-sample/src/main/kotlin/helios/sample/sample.kt
@@ -45,39 +45,45 @@ fun main(args: Array<String>) {
         println("Successfully decode the json: $it")
     })
 
-    root.name().string.fix().modify(companyJson, String::toUpperCase).let(::println)
+    root.name.string.fix().modify(companyJson, String::toUpperCase).let(::println)
 
-    root.address().street().name().string.fix().getOption(companyJson).let(::println)
+    root.address.street.name.string.fix().getOption(companyJson).let(::println)
 
-    val employeeLastNames: Traversal<Json, String> = root.employees().every().lastName().string.fix()
+    val employeeLastNames: Traversal<Json, String> = root.employees.every().lastName.string.fix()
 
     employeeLastNames.modify(companyJson, String::capitalize).let {
         employeeLastNames.getAll(it)
     }.let(::println)
 
-    root.employees().filterIndex { it == 0 }.select("name").string.getAll(companyJson).let(::println)
+    root.employees.filterIndex { it == 0 }.select("name").string.getAll(companyJson).let(::println)
 
-    root.employees().every().filterKeys { it == "name" }.string.getAll(companyJson).let(::println)
+    root.employees.every().filterKeys { it == "name" }.string.getAll(companyJson).let(::println)
 
 }
 
 /**
  * Generated code for Company
  */
-fun <F> JsonPathFunctions<F>.name(): JsonPathFunctions<F> = select("name")
-fun <F> JsonPathFunctions<F>.address(): JsonPathFunctions<F> = select("address")
-fun <F> JsonPathFunctions<F>.employees(): JsonPathFunctions<F> = select("employees")
+val <F> JsonPathFunctions<F>.name: JsonPathFunctions<F>
+    get() = select("name")
+val <F> JsonPathFunctions<F>.address: JsonPathFunctions<F>
+    get() = select("address")
+val <F> JsonPathFunctions<F>.employees: JsonPathFunctions<F>
+    get() = select("employees")
 
 /**
  * Generated code for Address
  */
-fun <F> JsonPathFunctions<F>.city(): JsonPathFunctions<F> = select("city")
-fun <F> JsonPathFunctions<F>.street(): JsonPathFunctions<F> = select("street")
+val <F> JsonPathFunctions<F>.city: JsonPathFunctions<F>
+    get() = select("city")
+val <F> JsonPathFunctions<F>.street: JsonPathFunctions<F>
+    get() = select("street")
 
 /**
  * Generated code for Street
  */
-fun <F> JsonPathFunctions<F>.number(): JsonPathFunctions<F> = select("number")
+val <F> JsonPathFunctions<F>.number: JsonPathFunctions<F>
+    get() = select("number")
 //fun <F> JsonPathFunctions<F>.name(): JsonPathFunctions<F> = select("name") <-- conflict with Company.name && Employee.name
 
 
@@ -85,4 +91,5 @@ fun <F> JsonPathFunctions<F>.number(): JsonPathFunctions<F> = select("number")
  * Generated code for Employee
  */
 //fun <F> JsonPathFunctions<F>.name(): JsonPathFunctions<F> = select("name") <-- conflict with Company.name && Street.name
-fun <F> JsonPathFunctions<F>.lastName(): JsonPathFunctions<F> = select("lastName")
+val <F> JsonPathFunctions<F>.lastName: JsonPathFunctions<F>
+    get() = select("lastName")

--- a/helios-sample/src/main/kotlin/helios/sample/sample.kt
+++ b/helios-sample/src/main/kotlin/helios/sample/sample.kt
@@ -1,12 +1,12 @@
 package helios.sample
 
 import arrow.core.Either
-import arrow.optics.Traversal
-import arrow.optics.modify
 import helios.core.Json
 import helios.optics.JsonPath.Companion.root
-import helios.optics.extract
-import helios.optics.selectExtract
+import helios.optics.JsonPathFunctions
+import helios.optics.Traversal
+import helios.optics.fix
+import helios.optics.modify
 import helios.typeclasses.Decoder
 import helios.typeclasses.DecodingError
 import helios.typeclasses.decoder
@@ -45,22 +45,44 @@ fun main(args: Array<String>) {
         println("Successfully decode the json: $it")
     })
 
-    root.selectExtract<String>("name").modify(companyJson) { chrs ->
-        chrs.toUpperCase()
-    }.let(::println)
+    root.name().string.fix().modify(companyJson, String::toUpperCase).let(::println)
 
-    root.select("address").select("street").selectExtract<String>("name").getOption(companyJson).let(::println)
+    root.address().street().name().string.fix().getOption(companyJson).let(::println)
 
-    val employeeLastNames: Traversal<Json, String> = root.select("employees").every().select("lastName").extract()
+    val employeeLastNames: Traversal<Json, String> = root.employees().every().lastName().string.fix()
 
     employeeLastNames.modify(companyJson, String::capitalize).let {
         employeeLastNames.getAll(it)
     }.let(::println)
 
-    root.select("employees").filterIndex { it == 0 }.select("name").extract<String>()
-            .getAll(companyJson).let(::println)
+    root.employees().filterIndex { it == 0 }.select("name").string.getAll(companyJson).let(::println)
 
-    root.select("employees").every().filterKeys { it == "name" }
-            .string.getAll(companyJson).let(::println)
+    root.employees().every().filterKeys { it == "name" }.string.getAll(companyJson).let(::println)
 
 }
+
+/**
+ * Generated code for Company
+ */
+fun <F> JsonPathFunctions<F>.name(): JsonPathFunctions<F> = select("name")
+fun <F> JsonPathFunctions<F>.address(): JsonPathFunctions<F> = select("address")
+fun <F> JsonPathFunctions<F>.employees(): JsonPathFunctions<F> = select("employees")
+
+/**
+ * Generated code for Address
+ */
+fun <F> JsonPathFunctions<F>.city(): JsonPathFunctions<F> = select("city")
+fun <F> JsonPathFunctions<F>.street(): JsonPathFunctions<F> = select("street")
+
+/**
+ * Generated code for Street
+ */
+fun <F> JsonPathFunctions<F>.number(): JsonPathFunctions<F> = select("number")
+//fun <F> JsonPathFunctions<F>.name(): JsonPathFunctions<F> = select("name") <-- conflict with Company.name && Employee.name
+
+
+/**
+ * Generated code for Employee
+ */
+//fun <F> JsonPathFunctions<F>.name(): JsonPathFunctions<F> = select("name") <-- conflict with Company.name && Street.name
+fun <F> JsonPathFunctions<F>.lastName(): JsonPathFunctions<F> = select("lastName")


### PR DESCRIPTION
Small POC for typed DSL [result](https://github.com/47deg/helios/blob/152f2624bffee6ecf1e1bc94653506bda2583108/helios-sample/src/main/kotlin/helios/sample/sample.kt#L48).

* Made Optics available as Kind (duplicated Arrow-optics code to do so)
* Using Kinds makes API less user-friendly:
   * `root.extract<City>(decoder(), encoder()).fix().getOption(cityJson)` vs `  root.extract<City>().getOption(cityJson)` 
    * `fix` to obtain the desired Optic.

The benefit is that we'd generate the type DSL on `JsonPathFunctions<F>` instead of both `JsonPath` / `JsonTraversalPath` and in the future perhaps `JsonFoldPath`.

I would prefer more generated code with better API. Thoughts?

Also, how would we handle conflicts in generated code like [here](https://github.com/47deg/helios/pull/6/files#diff-fa4bceb949758a9ad3dda6ed0029d40fR67)?