### PR TITLE
Dsl syntax compiler

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ buildscript {
         kotlinVersion = '1.2.20'
         kotlinxCoroutinesVersion = '0.20'
         kotlinxCollectionsImmutableVersion = '0.1'
-        arrowVersion = '0.6.1'
+        arrowVersion = '0.6.2-SNAPSHOT'
     }
 
     repositories {

--- a/helios-core/src/main/kotlin/helios/core/helios.kt
+++ b/helios-core/src/main/kotlin/helios/core/helios.kt
@@ -93,7 +93,7 @@ const val MinLongString = "-9223372036854775808"
                 lhs.toList().fold(rhs) { acc, (key, value) ->
                     rhs[key].fold({ acc.add(key, value) }, { r -> acc.add(key, value.merge(r)) })
                 }
-            }).ev().getOrElse { that }
+            }).fix().getOrElse { that }
 
     abstract fun toJsonString(): String
 

--- a/helios-core/src/main/kotlin/helios/instances/java_util.kt
+++ b/helios-core/src/main/kotlin/helios/instances/java_util.kt
@@ -2,7 +2,7 @@ package java_util
 
 import arrow.core.Either
 import arrow.core.applicative
-import arrow.core.ev
+import arrow.core.fix
 import arrow.core.identity
 import arrow.data.k
 import helios.core.*
@@ -32,7 +32,7 @@ interface ListDecoderInstance<A> : Decoder<List<A>> {
             value.asJsArray().toList()
                     .flatMap {
                         it.value.map { decoderA().decode(it) }
-                    }.k().traverse(::identity, Either.applicative()).ev().map { it.list }
+                    }.k().traverse(::identity, Either.applicative()).fix().map { it.list }
 }
 
 object ListDecoderInstanceImplicits {

--- a/helios-dsl-syntax-compiler/build.gradle
+++ b/helios-dsl-syntax-compiler/build.gradle
@@ -1,0 +1,20 @@
+import org.gradle.internal.jvm.Jvm
+
+apply plugin: 'kotlin'
+apply plugin: 'kotlin-kapt'
+
+dependencies {
+    compile project(":helios-meta")
+    compile "io.arrow-kt:arrow-annotations-processor:$arrowVersion"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlinVersion"
+    compile 'me.eugeniomarletti:kotlin-metadata:1.2.1'
+    compileOnly 'com.google.auto.service:auto-service:1.0-rc3'
+    kapt 'com.google.auto.service:auto-service:1.0-rc3'
+
+    testCompile group: 'junit', name: 'junit', version: '4.12'
+    testCompile "com.google.testing.compile:compile-testing:0.6"
+    testCompile fileTree(dir: './src/test/libs', includes: ['*.jar'])
+    testCompile files(Jvm.current().getToolsJar())
+}
+
+apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/helios-dsl-syntax-compiler/gradle.properties
+++ b/helios-dsl-syntax-compiler/gradle.properties
@@ -1,0 +1,4 @@
+# Maven publishing configuration
+POM_NAME=Helios Dsl Syntax Compiler
+POM_ARTIFACT_ID=helios-dsl-syntax-compiler
+POM_PACKAGING=jar

--- a/helios-dsl-syntax-compiler/src/main/kotlin/helios/meta/compiler/json/JsonAnnotated.kt
+++ b/helios-dsl-syntax-compiler/src/main/kotlin/helios/meta/compiler/json/JsonAnnotated.kt
@@ -1,0 +1,9 @@
+package helios.meta.compiler.json
+
+import arrow.common.utils.ClassOrPackageDataWrapper
+import org.jetbrains.kotlin.serialization.ProtoBuf
+import javax.lang.model.element.TypeElement
+
+class JsonAnnotated(
+        val classElement: TypeElement,
+        val classOrPackageProto: ClassOrPackageDataWrapper)

--- a/helios-dsl-syntax-compiler/src/main/kotlin/helios/meta/compiler/json/JsonAnnotationInfo.kt
+++ b/helios-dsl-syntax-compiler/src/main/kotlin/helios/meta/compiler/json/JsonAnnotationInfo.kt
@@ -1,0 +1,7 @@
+package helios.meta.compiler.json
+
+import helios.meta.json
+
+val jsonAnnotationKClass = json::class
+val jsonAnnotationClass = jsonAnnotationKClass.java
+val jsonAnnotationName = "@" + jsonAnnotationClass.simpleName

--- a/helios-dsl-syntax-compiler/src/main/kotlin/helios/meta/compiler/json/JsonDslSyntaxFileGenerator.kt
+++ b/helios-dsl-syntax-compiler/src/main/kotlin/helios/meta/compiler/json/JsonDslSyntaxFileGenerator.kt
@@ -1,0 +1,46 @@
+package helios.meta.compiler.json
+
+import arrow.common.Package
+import arrow.common.utils.ClassOrPackageDataWrapper
+import arrow.common.utils.extractFullName
+import arrow.common.utils.removeBackticks
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.serialization.ProtoBuf
+import org.jetbrains.kotlin.serialization.deserialization.NameResolver
+import java.io.File
+
+data class JsonElement(
+        val `package`: Package,
+        val target: JsonAnnotated
+) {
+    val properties: List<ProtoBuf.Property> = (target.classOrPackageProto as ClassOrPackageDataWrapper.Class).propertyList
+    val nameResolver: NameResolver
+            inline get() = target.classOrPackageProto.nameResolver
+}
+
+class JsonDslSyntaxFileGenerator(
+        private val generatedDir: File,
+        jsonAnnotatedList: List<JsonAnnotated>
+) {
+
+    private val packageSyntax: List<Pair<Package, List<Name>>> = jsonAnnotatedList
+            .map { JsonElement(it.classOrPackageProto.`package`, it) }
+            .groupBy(JsonElement::`package`)
+            .mapValues { (_, v) -> v.flatMap { element -> element.properties.map { element.nameResolver.getName(it.name) } }.distinct() }
+            .toList()
+
+    /**
+     * Main entry point for json dsl syntax generation
+     */
+    fun generate() = packageSyntax.forEach { (`package`, names) ->
+        val content = names.joinToString(prefix = "package $`package`\n\n", separator = "\n") {
+            """
+            |val helios.optics.JsonPath.$it
+            |    inline get() = select("$it")
+            |""".trimMargin()
+        }
+        val file = File(generatedDir, "${jsonAnnotationClass.simpleName}.helios.dsl.syntax.$`package`.kt")
+        file.writeText(content)
+    }
+
+}

--- a/helios-dsl-syntax-compiler/src/main/kotlin/helios/meta/compiler/json/JsonDslSyntaxProcessor.kt
+++ b/helios-dsl-syntax-compiler/src/main/kotlin/helios/meta/compiler/json/JsonDslSyntaxProcessor.kt
@@ -1,0 +1,47 @@
+package helios.meta.compiler.json
+
+import com.google.auto.service.AutoService
+import arrow.common.utils.AbstractProcessor
+import arrow.common.utils.knownError
+import java.io.File
+import javax.annotation.processing.Processor
+import javax.annotation.processing.RoundEnvironment
+import javax.lang.model.SourceVersion
+import javax.lang.model.element.ElementKind
+import javax.lang.model.element.TypeElement
+
+@AutoService(Processor::class)
+class JsonDslSyntaxProcessor : AbstractProcessor() {
+
+    private val jsonAnnotatedList: MutableList<JsonAnnotated> = mutableListOf<JsonAnnotated>()
+
+    override fun getSupportedSourceVersion(): SourceVersion = SourceVersion.latestSupported()
+
+    override fun getSupportedAnnotationTypes(): Set<String> = setOf(jsonAnnotationClass.canonicalName)
+
+    /**
+     * Processor entry point
+     */
+    override fun onProcess(annotations: Set<TypeElement>, roundEnv: RoundEnvironment) {
+        jsonAnnotatedList += roundEnv
+                .getElementsAnnotatedWith(jsonAnnotationClass)
+                .map { element ->
+                    when (element.kind) {
+                        ElementKind.CLASS -> processClass(element as TypeElement)
+                        else -> knownError("${jsonAnnotationName} can only be used on immutable data classes")
+                    }
+                }
+
+        if (roundEnv.processingOver()) {
+            val generatedDir = File(this.generatedDir!!, jsonAnnotationClass.simpleName).also { it.mkdirs() }
+            JsonDslSyntaxFileGenerator(generatedDir, jsonAnnotatedList).generate()
+        }
+    }
+
+    private fun processClass(element: TypeElement): JsonAnnotated {
+        val proto = getClassOrPackageDataWrapper(element)
+        return JsonAnnotated(element, proto)
+    }
+
+
+}

--- a/helios-meta-compiler/src/main/kotlin/helios/meta/compiler/json/JsonFileGenerator.kt
+++ b/helios-meta-compiler/src/main/kotlin/helios/meta/compiler/json/JsonFileGenerator.kt
@@ -59,7 +59,7 @@ class JsonFileGenerator(
 
     private fun createInstance(je: JsonElement): String = """|Either.applicative<DecodingError>().map(${je.pairs.map { (p, t) -> "value[\"$p\"].fold({Either.Left(KeyNotFound(\"$p\"))}, { decoder<$t>().decode(it)})" }.joinToString(prefix = "\n\t", separator = ",\n\t", postfix = "\n")}, { ${je.pairs.map { (p, _) -> p }.joinToString(prefix = if (je.pairs.size > 1) "(" else "", separator = ",", postfix = if (je.pairs.size > 1) ")" else "")} ->
             |  ${je.name}(${je.pairs.map { (p, _) -> "$p = $p" }.joinToString(",")})
-            |}).ev()
+            |}).fix()
             |""".trimMargin()
 
     private fun genToJson(je: JsonElement): String =

--- a/helios-optics/build.gradle
+++ b/helios-optics/build.gradle
@@ -3,7 +3,7 @@ dependencies {
     compile project(":helios-meta")
     compile project(":helios-parser")
     compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlinVersion"
-    compile "io.arrow-kt:arrow-optics:0.6.2-SNAPSHOT"
+    compile "io.arrow-kt:arrow-optics:$arrowVersion"
     compile "io.arrow-kt:arrow-typeclasses:$arrowVersion"
     compileOnly project(':helios-meta-compiler')
 

--- a/helios-optics/src/main/kotlin/helios/optics/JsonDSL.kt
+++ b/helios-optics/src/main/kotlin/helios/optics/JsonDSL.kt
@@ -7,6 +7,8 @@ import arrow.optics.typeclasses.Index
 import arrow.optics.typeclasses.at
 import arrow.optics.typeclasses.index
 import helios.core.*
+import helios.instances.StringDecoderInstance
+import helios.instances.StringEncoderInstance
 import helios.typeclasses.Decoder
 import helios.typeclasses.Encoder
 import helios.typeclasses.decoder
@@ -37,34 +39,39 @@ data class JsonPath(val json: Optional<Json, Json>) {
     val boolean: Optional<Json, Boolean> = json compose jsonJsBoolean() compose jsBooleanIso()
 
     /**
+     * Extract value as [CharSequence] from path.
+     */
+    val charseq: Optional<Json, CharSequence> = json compose jsonJsString() compose jsStringIso()
+
+    /**
      * Extract value as [String] from path.
      */
-    val string: Optional<Json, CharSequence> = json compose jsonJsString() compose jsStringIso()
+    val string: Optional<Json, String> = extract(StringEncoderInstance, StringDecoderInstance)
 
     /**
      * Extract value as [JsNumber] from path.
      */
-    val number: Optional<Json, JsNumber> = json compose jsonJsNumber()
+    val jsnumber: Optional<Json, JsNumber> = json compose jsonJsNumber()
 
     /**
      * Extract value as [JsDecimal] from path.
      */
-    val decimal: Optional<Json, String> = number compose jsNumberJsDecimal() compose jsDecimalIso()
+    val decimal: Optional<Json, String> = jsnumber compose jsNumberJsDecimal() compose jsDecimalIso()
 
     /**
      * Extract value as [Long] from path.
      */
-    val long: Optional<Json, Long> = number compose jsNumberJsLong() compose jsLongIso()
+    val long: Optional<Json, Long> = jsnumber compose jsNumberJsLong() compose jsLongIso()
 
     /**
      * Extract value as [Float] from path.
      */
-    val float: Optional<Json, Float> = number compose jsNumberJsFloat() compose jsFloatIso()
+    val float: Optional<Json, Float> = jsnumber compose jsNumberJsFloat() compose jsFloatIso()
 
     /**
      * Extract value as [Int] from path.
      */
-    val int: Optional<Json, Int> = number compose jsNumberJsInt() compose jsIntIso()
+    val int: Optional<Json, Int> = jsnumber compose jsNumberJsInt() compose jsIntIso()
 
     /**
      * Extract [JsArray] as `List<Json>` from path.

--- a/helios-sample/build.gradle
+++ b/helios-sample/build.gradle
@@ -5,6 +5,7 @@ dependencies {
 
     kapt "io.arrow-kt:arrow-annotations-processor:$arrowVersion"
     kapt project(':helios-meta-compiler')
+    kapt project(':helios-dsl-syntax-compiler')
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/helios-sample/src/main/kotlin/helios/sample/sample.kt
+++ b/helios-sample/src/main/kotlin/helios/sample/sample.kt
@@ -3,9 +3,7 @@ package helios.sample
 import arrow.core.Either
 import arrow.optics.modify
 import helios.core.Json
-import helios.optics.JsonPath.Companion.root
-import helios.optics.extract
-import helios.optics.selectExtract
+import helios.optics.JsonPath
 import helios.typeclasses.Decoder
 import helios.typeclasses.DecodingError
 import helios.typeclasses.decoder
@@ -42,9 +40,8 @@ fun main(args: Array<String>) {
         println("Successfully decode the json: $it")
     })
 
-    root.selectExtract<String>("name").modify(companyJson) { chrs ->
-        chrs.toUpperCase()
-    }.let(::println)
+    JsonPath.root.name.string.modify(companyJson, String::toUpperCase).let(::println)
 
-    root.select("address").select("street").selectExtract<String>("name").getOption(companyJson).let(::println)
+    JsonPath.root.address.street.name.string.getOption(companyJson).let(::println)
+
 }

--- a/helios-sample/src/main/kotlin/helios/sample/sample.kt
+++ b/helios-sample/src/main/kotlin/helios/sample/sample.kt
@@ -30,8 +30,9 @@ const val companyJsonString = """
 
 fun main(args: Array<String>) {
 
-    val companyDecoder: Decoder<Company> = decoder()
     val companyJson: Json = Json.parseUnsafe(companyJsonString)
+
+    val companyDecoder: Decoder<Company> = decoder()
     val errorOrCompany: Either<DecodingError, Company> = companyDecoder.decode(companyJson)
 
     errorOrCompany.fold({
@@ -40,8 +41,10 @@ fun main(args: Array<String>) {
         println("Successfully decode the json: $it")
     })
 
+    JsonPath.root.select("name").string.modify(companyJson, String::toUpperCase).let(::println)
     JsonPath.root.name.string.modify(companyJson, String::toUpperCase).let(::println)
 
+    JsonPath.root.select("address").select("street").select("name").string.getOption(companyJson).let(::println)
     JsonPath.root.address.street.name.string.getOption(companyJson).let(::println)
 
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,4 +7,5 @@ include ':helios-parser'
 include ':helios-benchmarks'
 include ':helios-sample'
 include ':helios-optics'
+include 'helios-dsl-syntax-compiler'
 


### PR DESCRIPTION
In case of ambiguous overloads, i.e same property names / json keys across  different packages, you need to rename the import when using star imports.

Given following domain.
```kotlin
package company
@json data class Person(val name: String)

package friends
@json data class Friend(val name: String)
```

Following snippet will **not** compile
```kotlin
import company.*
import friends.*

JsonPath.root.name.string.getOption(companyJson)
JsonPath.root.name.string.getOption(friendsJson)
```

But following snippet will compile
```kotlin
import company.name
import friends.name as friendName

JsonPath.root.name.string.getOption(companyJson)
JsonPath.root.friendName.string.getOption(friendsJson)
```

Since imports work on package all ambiguous overloads for a given package are removed during the compilation step. i.e.

```kotlin
package domain

@json data class Street(val number: Int, val name: String)
@json data class Employee(val name: String)
```