### PR TITLE
Adds benchmarks to travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ jdk:
 
 script:
 - ./gradlew clean build test
+- ./gradlew :helios-benchmarks:jmh

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ buildscript {
     dependencies {
         classpath "com.github.ben-manes:gradle-versions-plugin:$gradleVersionsPluginVersion"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+        classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlinVersion"
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
         classpath 'io.arrow-kt:ank-gradle-plugin:0.7.1'
         classpath 'org.ajoberstar:gradle-git-publish:1.0.1'

--- a/helios-benchmarks/build.gradle
+++ b/helios-benchmarks/build.gradle
@@ -1,9 +1,14 @@
+repositories {
+    maven { url "https://kotlin.bintray.com/kotlinx" }
+}
+
 dependencies {
     compile project(":helios-core")
     compile project(":helios-meta")
     compile project(":helios-parser")
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
+    compile "org.jetbrains.kotlinx:kotlinx-serialization-runtime:0.9.0"
     compile 'com.beust:klaxon:3.0.11'
     compile 'com.tomatobean:jsonparser:1.0.10'
     compile 'com.squareup.moshi:moshi-kotlin:1.8.0'
@@ -19,6 +24,7 @@ dependencies {
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')
 apply plugin: "me.champeau.gradle.jmh"
 apply plugin: 'kotlin-kapt'
+apply plugin: 'kotlinx-serialization'
 
 jmh {
     resultFormat = 'csv'

--- a/helios-benchmarks/build.gradle
+++ b/helios-benchmarks/build.gradle
@@ -1,5 +1,7 @@
 dependencies {
     compile project(":helios-core")
+    compile project(":helios-meta")
+    compile project(":helios-parser")
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
     compile 'com.beust:klaxon:3.0.11'

--- a/helios-benchmarks/src/jmh/kotlin/helios/benchmarks/Decoding.kt
+++ b/helios-benchmarks/src/jmh/kotlin/helios/benchmarks/Decoding.kt
@@ -2,35 +2,32 @@ package helios.benchmarks
 
 import com.beust.klaxon.JsonObject
 import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.ObjectReader
 import com.github.salomonbrys.kotson.fromJson
 import com.google.gson.JsonElement
-import com.squareup.moshi.JsonAdapter
-import com.squareup.moshi.Moshi
 import helios.benchmarks.sample.*
 import helios.core.Json
 import org.openjdk.jmh.annotations.*
 
 @State(Scope.Benchmark)
 @Fork(1)
-@Warmup(iterations = 10)
-@Measurement(iterations = 10)
+@Warmup(iterations = 2)
+@Measurement(iterations = 5)
 open class Decoding {
 
   @Benchmark
-  fun klaxon(): Friends = Parsed.Klaxon.parseFromJsonObject<Friends>(Parsed.klaxonJson)!!
+  fun klaxon(): Friends = klaxon.parseFromJsonObject<Friends>(Parsed.klaxonJson)!!
 
   @Benchmark
   fun kotson(): Friends = gson.fromJson(Parsed.kotsonJson, Friends::class.java)
 
   @Benchmark
-  fun moshi(): Friends = Parsed.moshiFriends.fromJsonValue(Parsed.moshiObject)!!
+  fun moshi(): Friends = moshiFriends.fromJsonValue(Parsed.moshiObject)!!
 
   @Benchmark
-  fun jackson(): Friends = Parsed.jacksonFriendsReader.readValue(Parsed.jacksonJson)
+  fun jackson(): Friends = jacksonFriendsReader.readValue(Parsed.jacksonJson)
 
   @Benchmark
-  fun helios(): Friends = Parsed.heliosFriendsDecoder.decode(Parsed.heliosJson).fold({
+  fun helios(): Friends = heliosFriendsDecoder.decode(Parsed.heliosJson).fold({
     throw RuntimeException(it.toString())
   }, { it })
 
@@ -38,21 +35,13 @@ open class Decoding {
 
 object Parsed {
 
-  val Klaxon = com.beust.klaxon.Klaxon()
-
-  val moshiFriends: JsonAdapter<Friends> = Moshi.Builder().build().adapter(Friends::class.java)
-
-  val klaxonJson: JsonObject = klaxon.parse(StringBuilder(jsonString)) as JsonObject
+  val klaxonJson: JsonObject = klaxonParser.parse(StringBuilder(jsonString)) as JsonObject
 
   val kotsonJson: JsonElement = gson.fromJson(jsonString)
 
   val moshiObject: Map<String, Any?> = moshi.fromJson(jsonString)!!
 
-  val jacksonFriendsReader: ObjectReader = jackson.readerFor(Friends::class.java)
-
   val jacksonJson: JsonNode = jackson.readTree(jsonString)
-
-  val heliosFriendsDecoder = Friends.decoder()
 
   val heliosJson: Json = Json.parseUnsafe(jsonString)
 

--- a/helios-benchmarks/src/jmh/kotlin/helios/benchmarks/Decoding.kt
+++ b/helios-benchmarks/src/jmh/kotlin/helios/benchmarks/Decoding.kt
@@ -7,7 +7,7 @@ import com.github.salomonbrys.kotson.fromJson
 import com.google.gson.JsonElement
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
-import helios.benchmarks.sample.Friends
+import helios.benchmarks.sample.*
 import helios.core.Json
 import org.openjdk.jmh.annotations.*
 
@@ -52,7 +52,7 @@ object Parsed {
 
   val jacksonJson: JsonNode = jackson.readTree(jsonString)
 
-  val heliosFriendsDecoder = decoder<Friends>()
+  val heliosFriendsDecoder = Friends.decoder()
 
   val heliosJson: Json = Json.parseUnsafe(jsonString)
 

--- a/helios-benchmarks/src/jmh/kotlin/helios/benchmarks/DecodingFromRaw.kt
+++ b/helios-benchmarks/src/jmh/kotlin/helios/benchmarks/DecodingFromRaw.kt
@@ -1,0 +1,37 @@
+package helios.benchmarks
+
+import arrow.core.flatMap
+import helios.benchmarks.sample.*
+import helios.core.Json
+import kotlinx.serialization.json.JSON
+import org.openjdk.jmh.annotations.*
+
+@State(Scope.Benchmark)
+@Fork(1)
+@Warmup(iterations = 2)
+@Measurement(iterations = 5)
+open class DecodingFromRaw {
+
+  @Benchmark
+  fun klaxon(): Friends = klaxon.parse<Friends>(jsonString)!!
+
+  @Benchmark
+  fun kotson(): Friends = gson.fromJson(jsonString, Friends::class.java)
+
+  @Benchmark
+  fun moshi(): Friends = moshiFriends.fromJson(jsonString)!!
+
+  @Benchmark
+  fun jackson(): Friends = jacksonFriendsReader.readValue(jsonString)
+
+  @Benchmark
+  fun helios(): Friends =
+    Json.parseFromString(jsonString)
+      .flatMap{heliosFriendsDecoder.decode(it)}
+      .fold({throw RuntimeException(it.toString())}, { it })
+
+  @Benchmark
+  fun kotlinx(): Friends = JSON.parse(kotlinxFriendsSerializer, jsonString)
+
+}
+

--- a/helios-benchmarks/src/jmh/kotlin/helios/benchmarks/Parsing.kt
+++ b/helios-benchmarks/src/jmh/kotlin/helios/benchmarks/Parsing.kt
@@ -10,12 +10,12 @@ import org.openjdk.jmh.annotations.*
 
 @State(Scope.Benchmark)
 @Fork(1)
-@Warmup(iterations = 10)
-@Measurement(iterations = 10)
+@Warmup(iterations = 2)
+@Measurement(iterations = 5)
 open class Parsing {
 
   @Benchmark
-  fun klaxon(): JsonObject = klaxon.parse(StringBuilder(jsonString)) as JsonObject
+  fun klaxon(): JsonObject = klaxonParser.parse(StringBuilder(jsonString)) as JsonObject
 
   @Benchmark
   fun kotson(): JsonElement = gson.fromJson(jsonString)

--- a/helios-benchmarks/src/jmh/kotlin/helios/benchmarks/Setup.kt
+++ b/helios-benchmarks/src/jmh/kotlin/helios/benchmarks/Setup.kt
@@ -1,20 +1,31 @@
 package helios.benchmarks
 
-import com.beust.klaxon.Parser
+import com.beust.klaxon.*
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.ObjectReader
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.google.gson.Gson
 import com.squareup.moshi.*
-import helios.benchmarks.sample.sampleJson
+import helios.benchmarks.sample.*
 
 val jsonString: String = sampleJson
 
-val klaxon: Parser = Parser()
+val klaxonParser: Parser = Parser.default()
+
+val klaxon: Klaxon = com.beust.klaxon.Klaxon()
 
 val gson = Gson()
 
 val moshi: JsonAdapter<Map<String, Any>> = Moshi.Builder().build()
   .adapter(Types.newParameterizedType(Map::class.java, String::class.java, Any::class.java))
 
+val moshiFriends: JsonAdapter<Friends> = Moshi.Builder().build()
+  .adapter(Friends::class.java)
+
 val jackson: ObjectMapper = ObjectMapper().registerModule(KotlinModule())
 
+val jacksonFriendsReader: ObjectReader = jackson.readerFor(Friends::class.java)
+
+val heliosFriendsDecoder = Friends.decoder()
+
+val kotlinxFriendsSerializer = Friends.serializer()

--- a/helios-benchmarks/src/main/kotlin/helios/benchmarks/sample/SampleData.kt
+++ b/helios-benchmarks/src/main/kotlin/helios/benchmarks/sample/SampleData.kt
@@ -1,17 +1,21 @@
 package helios.benchmarks.sample
 
 import helios.meta.json
+import kotlinx.serialization.*
 
+@Serializable
 @json
 data class Friends(val friends: List<Friend>) {
   companion object
 }
 
+@Serializable
 @json
 data class NestedFriends(val id: Int, val name: String) {
   companion object
 }
 
+@Serializable
 @json
 data class Friend(
   val _id: String,


### PR DESCRIPTION
Fixes #29 
Fixes #32 

kotlinx doesn't allow to parsing to an intermediate state, this is why I've added a new benchmark that goes from `String` to `A`