### PR TITLE
Run benchmarks on master and PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ jdk:
 
 script:
 - ./gradlew clean build test
-- ./gradlew :helios-benchmarks:jmh
+- if [ "$TRAVIS_BRANCH" = "master" ]; then ./gradlew :helios-benchmarks:jmh; fi


### PR DESCRIPTION
We don't need the benchmarks on every commit, just in the PRs and on the master branch.