### PR TITLE
Fix Gradle task names

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ dependencies {
 To run the benchmarks for comparing Helios with other Json libraries, execute the following command:
 
 ```bash
-./gradlew :helios-benchmarks: executeBenchmarks
+./gradlew :helios-benchmarks:executeBenchmarks
 ```
 
 To run the benchmarks with Helios' performance, execute the following command:
 
 ```bash
-./gradlew :helios-benchmarks: executeHeliosBenchmark
+./gradlew :helios-benchmarks:executeHeliosBenchmark
 ```
 
 ## Running Microsite

--- a/docs/docs/benchmarks/README.md
+++ b/docs/docs/benchmarks/README.md
@@ -23,11 +23,11 @@ between Helios and some of the most common Kotlin Json libraries.
 To run the benchmarks for comparing Helios with other Json libraries, execute the following command:
 
 ```bash
-./gradlew :helios-benchmarks: executeBenchmarks
+./gradlew :helios-benchmarks:executeBenchmarks
 ```
 
 To run the benchmarks with Helios' performance, execute the following command:
 
 ```bash
-./gradlew :helios-benchmarks: executeHeliosBenchmark
+./gradlew :helios-benchmarks:executeHeliosBenchmark
 ```


### PR DESCRIPTION
Gradle interprets the space between the `:` and the real task name as the task name (i.e., it thinks the space *is* the task name). This PR fixes that so users can copy-paste the gradlew commands.