### PR TITLE
Prettify JsonFileGenerator output

### DIFF
--- a/helios-meta/src/main/kotlin/helios/meta/compiler/json/JsonFileGenerator.kt
+++ b/helios-meta/src/main/kotlin/helios/meta/compiler/json/JsonFileGenerator.kt
@@ -93,10 +93,10 @@ class JsonFileGenerator(
     }
 
   private fun jsonProperties(je: JsonElement): String =
-    je.pairs.joinToString(",", "JsObject(mapOf(", "))") { (p, r) ->
-      """|
-         |"$p" to ${r.encoder()}.run { $p.encode() }
-         |""".trimMargin()
+    je.pairs.joinToString(",\n", "JsObject(mapOf(\n", "\n))") { (p, r) ->
+      """
+         |  "$p" to ${r.encoder()}.run { $p.encode() }
+         """.trimMargin()
     }
 
   private fun String.complexDecoder(pre: String) = getTypeParameters.joinToString(


### PR DESCRIPTION
Before:
```kotlin
fun Address.toJson(): Json = JsObject(mapOf(
"city" to kotlin.String.encoder().run { city.encode() }
,
"number" to arrow.core.Option.Companion.encoder(kotlin.Int.encoder()).run { number.encode() }
,
"street" to helios.sample.Street.encoder().run { street.encode() }
))
```

After:
```kotlin
fun Address.toJson(): Json = JsObject(mapOf(
  "city" to kotlin.String.encoder().run { city.encode() },
  "number" to arrow.core.Option.Companion.encoder(kotlin.Int.encoder()).run { number.encode() },
  "street" to helios.sample.Street.encoder().run { street.encode() }
))
```