### PR TITLE
Clean up after Enum PR

### DIFF
--- a/docs/docs/coding/README.md
+++ b/docs/docs/coding/README.md
@@ -47,11 +47,11 @@ import arrow.core.*
 import helios.*
 import helios.instances.*
 
-val fooJson = Enum.Companion.encoder<Foo>().run {
+val fooJson = Enum.encoder<Foo>().run {
   Foo.A.encode()
 }
 
-Enum.Companion.decoder<Foo>().decode(fooJson)
+Enum.decoder<Foo>().decode(fooJson)
 ```
 
 ## Building a Json

--- a/helios-core/src/test/kotlin/helios/instances/EnumTest.kt
+++ b/helios-core/src/test/kotlin/helios/instances/EnumTest.kt
@@ -16,18 +16,18 @@ internal class EnumTest : UnitSpec() {
   init {
 
     "Enums should be encoded and decoded successfully" {
-      Enum.Companion.decoder<Foo>().decode(Enum.Companion.encoder<Foo>().run {
+      Enum.decoder<Foo>().decode(Enum.encoder<Foo>().run {
         Foo.A.encode()
       }).shouldBeRight(Foo.A)
     }
 
     "invalid enum value produces the correct error" {
-      val decoded = Enum.Companion.decoder<Foo>().decode(JsString("B"))
+      val decoded = Enum.decoder<Foo>().decode(JsString("B"))
       decoded.shouldBeLeft(EnumValueNotFound(JsString("B")))
     }
 
     "invalid json produces the correct error" {
-      val decoded = Enum.Companion.decoder<Foo>().decode(JsInt(1))
+      val decoded = Enum.decoder<Foo>().decode(JsInt(1))
       decoded.shouldBeLeft(StringDecodingError(JsInt(1)))
     }
 


### PR DESCRIPTION
This PR cleans up explicit uses of `Enum.Companion` where just `Enum` could be used instead.