### PR TITLE
Update retrofit dependency name

### DIFF
--- a/docs/docs/integrations/retrofit/README.md
+++ b/docs/docs/integrations/retrofit/README.md
@@ -13,7 +13,7 @@ permalink: /docs/integrations/retrofit/
 To start using **Helios** on a *Retrofit* project just add the following dependency:
 
 ```groovy
-"com.47deg:helios-integrations-retrofit:0.2.0"
+"com.47deg:helios-integration-retrofit:0.2.0"
 ```
 
 ## Usage


### PR DESCRIPTION
Fixes the README to point to the correct retrofit dependency.

Or you could update the package name to match the README.