### PR TITLE
Bump Arrow version 0.10.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,8 @@ local.properties
 reports/
 /out/
 
-KotlinTest
-.kotlintest
+kotest
+.kotest
 
 # Keystore files
 *.jks

--- a/build.gradle
+++ b/build.gradle
@@ -25,9 +25,9 @@ buildscript {
 
         // Libraries
         javaVersion = JavaVersion.VERSION_1_7
-        kotlinTestVersion = "3.1.11"
+        kotlinTestVersion = "3.4.1"
         kotlinVersion = "1.3.31"
-        arrowVersion = "0.9.0"
+        arrowVersion = "0.10.0"
         kotlinMetadataVersion = "1.4.0"
         googleTestingVersion = "0.15"
         autoServiceVersion = "1.0-rc5"
@@ -40,7 +40,7 @@ buildscript {
         kotsonVersion ="2.5.0"
         jacksonVersion = "2.9.8"
         jsoniterVersion = "0.9.23"
-        
+
         // Retrofit integration libraries
         retrofitVersion = "2.6.0"
         mockwebserverVersion = "3.14.2"
@@ -115,7 +115,7 @@ subprojects { project ->
 
         executionData fileTree(project.rootDir.absolutePath).include("**/build/jacoco/*.exec")
     }
-    
+
     bintray {
         publish = true
         user = findPropertyOrEnv("BINTRAY_USER") ?: "no.bintray.user"

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ buildscript {
         javaVersion = JavaVersion.VERSION_1_7
         kotlinTestVersion = "3.4.2"
         kotlinVersion = "1.3.31"
-        arrowVersion = "0.10.0"
+        arrowVersion = "0.10.2"
         kotlinMetadataVersion = "1.4.0"
         googleTestingVersion = "0.15"
         autoServiceVersion = "1.0-rc5"

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ buildscript {
         javaVersion = JavaVersion.VERSION_1_7
         kotlinTestVersion = "4.0.2758-SNAPSHOT"
         kotlinVersion = "1.3.31"
-        arrowVersion = "0.10.2"
+        arrowVersion = "0.10.3"
         kotlinMetadataVersion = "1.4.0"
         googleTestingVersion = "0.15"
         autoServiceVersion = "1.0-rc5"

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ buildscript {
 
         // Libraries
         javaVersion = JavaVersion.VERSION_1_7
-        kotlinTestVersion = "3.4.1"
+        kotlinTestVersion = "3.4.2"
         kotlinVersion = "1.3.31"
         arrowVersion = "0.10.0"
         kotlinMetadataVersion = "1.4.0"
@@ -78,6 +78,16 @@ def findPropertyOrEnv(String key) {
     [project.properties[key], System.getenv(key)].find { it != null }
 }
 
+configurations.all {
+    resolutionStrategy {
+        eachDependency { DependencyResolveDetails details ->
+            if (details.requested.group == 'io.arrow-kt') {
+                details.useVersion "0.10.0"
+            }
+        }
+    }
+}
+
 subprojects { project ->
 
     repositories {
@@ -87,6 +97,7 @@ subprojects { project ->
         maven { url "http://dl.bintray.com/arrow-kt/arrow-kt" }
         maven { url "https://dl.bintray.com/jetbrains/markdown/" }
         maven { url "https://jitpack.io" }
+        maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
     }
 
     apply plugin: "kotlin"

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ buildscript {
 
         // Libraries
         javaVersion = JavaVersion.VERSION_1_7
-        kotlinTestVersion = "3.4.2"
+        kotlinTestVersion = "4.0.2758-SNAPSHOT"
         kotlinVersion = "1.3.31"
         arrowVersion = "0.10.2"
         kotlinMetadataVersion = "1.4.0"
@@ -82,10 +82,14 @@ configurations.all {
     resolutionStrategy {
         eachDependency { DependencyResolveDetails details ->
             if (details.requested.group == 'io.arrow-kt') {
-                details.useVersion "0.10.0"
+                details.useVersion "0.10.2"
             }
         }
     }
+    exclude group: "io.kotlintest", module: "kotlintest-assertions"
+    exclude group: "io.kotlintest", module: "kotlintest-extensions"
+    exclude group: "io.kotlintest", module: "kotlintest-runner-junit5"
+    exclude group: "io.kotlintest", module: "kotlintest-runner-jvm"
 }
 
 subprojects { project ->

--- a/helios-core/build.gradle
+++ b/helios-core/build.gradle
@@ -11,15 +11,15 @@ dependencies {
     kapt "io.arrow-kt:arrow-meta:$arrowVersion"
     kapt project(":helios-meta")
 
-    testImplementation("io.arrow-kt:arrow-test:$arrowVersion")
-    testImplementation("io.kotlintest:kotlintest-runner-junit5:$kotlinTestVersion")
-    testImplementation("io.kotlintest:kotlintest-assertions-arrow:$kotlinTestVersion")
+    testImplementation("io.kotest:kotest-runner-junit5:$kotlinTestVersion")
+    testImplementation("io.kotest:kotest-assertions-arrow:$kotlinTestVersion")
 
     kaptTest project(":helios-meta")
     kaptTest "io.arrow-kt:arrow-meta:$arrowVersion"
 
     testCompile project(":helios-test")
     testCompileOnly "io.arrow-kt:arrow-meta:$arrowVersion"
+    testCompileOnly "io.arrow-kt:arrow-optics:$arrowVersion"
     testCompileOnly project(":helios-meta")
 }
 

--- a/helios-core/build.gradle
+++ b/helios-core/build.gradle
@@ -5,11 +5,8 @@ dependencies {
     compile project(":helios-parser")
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
-    compile "io.arrow-kt:arrow-core-data:$arrowVersion"
-    compile "io.arrow-kt:arrow-core-extensions:$arrowVersion"
+    compile "io.arrow-kt:arrow-core:$arrowVersion"
     compile "io.arrow-kt:arrow-syntax:$arrowVersion"
-    compile "io.arrow-kt:arrow-extras-data:$arrowVersion"
-    compile "io.arrow-kt:arrow-extras-extensions:$arrowVersion"
 
     kapt "io.arrow-kt:arrow-meta:$arrowVersion"
     kapt project(":helios-meta")
@@ -17,14 +14,13 @@ dependencies {
     testImplementation("io.arrow-kt:arrow-test:$arrowVersion")
     testImplementation("io.kotlintest:kotlintest-runner-junit5:$kotlinTestVersion")
     testImplementation("io.kotlintest:kotlintest-assertions-arrow:$kotlinTestVersion")
-    
+
     kaptTest project(":helios-meta")
     kaptTest "io.arrow-kt:arrow-meta:$arrowVersion"
 
     testCompile project(":helios-test")
     testCompileOnly "io.arrow-kt:arrow-meta:$arrowVersion"
     testCompileOnly project(":helios-meta")
-    
 }
 
 apply from: rootProject.file("gradle/generated-kotlin-sources.gradle")

--- a/helios-core/src/main/kotlin/helios/instances/instances.kt
+++ b/helios-core/src/main/kotlin/helios/instances/instances.kt
@@ -2,7 +2,7 @@ package helios.instances
 
 import arrow.core.*
 import arrow.core.extensions.either.applicative.applicative
-import arrow.core.extensions.either.applicative.map2
+import arrow.core.extensions.either.apply.map2
 import arrow.extension
 import helios.core.*
 import helios.syntax.json.asJsArrayOrError

--- a/helios-core/src/main/kotlin/helios/instances/instancesArrow.kt
+++ b/helios-core/src/main/kotlin/helios/instances/instancesArrow.kt
@@ -2,8 +2,7 @@ package helios.instances
 
 import arrow.core.*
 import arrow.core.extensions.either.applicative.applicative
-import arrow.core.extensions.either.applicative.map2
-import arrow.data.NonEmptyList
+import arrow.core.extensions.either.apply.map2
 import helios.core.*
 import helios.syntax.json.asJsArrayOrError
 import helios.typeclasses.Decoder

--- a/helios-core/src/main/kotlin/helios/instances/instancesCollections.kt
+++ b/helios-core/src/main/kotlin/helios/instances/instancesCollections.kt
@@ -2,10 +2,9 @@ package helios.instances
 
 import arrow.core.*
 import arrow.core.extensions.either.applicative.applicative
-import arrow.core.extensions.either.applicative.map2
-import arrow.data.extensions.list.foldable.foldLeft
-import arrow.data.extensions.list.traverse.sequence
-import arrow.data.fix
+import arrow.core.extensions.either.apply.map2
+import arrow.core.extensions.list.foldable.foldLeft
+import arrow.core.extensions.list.traverse.sequence
 import arrow.extension
 import helios.core.*
 import helios.syntax.json.asJsArrayOrError

--- a/helios-core/src/main/kotlin/helios/instances/instancesEq.kt
+++ b/helios-core/src/main/kotlin/helios/instances/instancesEq.kt
@@ -1,7 +1,7 @@
 package helios.instances
 
 import arrow.core.extensions.eq
-import arrow.data.extensions.list.foldable.forAll
+import arrow.core.extensions.list.foldable.forAll
 import arrow.extension
 import arrow.typeclasses.Eq
 import helios.core.*

--- a/helios-core/src/test/kotlin/helios/core/HeliosTest.kt
+++ b/helios-core/src/test/kotlin/helios/core/HeliosTest.kt
@@ -1,12 +1,12 @@
 package helios.core
 
 import arrow.core.Right
-import arrow.test.UnitSpec
+import helios.arrow.UnitSpec
 import helios.core.model.Friend
 import helios.core.model.decoder
 import helios.core.model.genFriend
 import helios.core.model.toJson
-import io.kotlintest.properties.forAll
+import io.kotest.properties.forAll
 
 class HeliosTest : UnitSpec() {
 

--- a/helios-core/src/test/kotlin/helios/core/JsNumberTest.kt
+++ b/helios-core/src/test/kotlin/helios/core/JsNumberTest.kt
@@ -1,11 +1,13 @@
 package helios.core
 
 import arrow.core.some
-import arrow.test.UnitSpec
+import helios.arrow.UnitSpec
 import helios.instances.jsnumber.eq.eq
-import io.kotlintest.properties.Gen
-import io.kotlintest.properties.forAll
-import io.kotlintest.shouldBe
+import io.kotest.properties.Gen
+import io.kotest.properties.list
+import io.kotest.properties.long
+import io.kotest.properties.forAll
+import io.kotest.shouldBe
 
 class JsNumberTest : UnitSpec() {
 

--- a/helios-core/src/test/kotlin/helios/core/model/SampleData.kt
+++ b/helios-core/src/test/kotlin/helios/core/model/SampleData.kt
@@ -2,10 +2,13 @@ package helios.core.model
 
 import arrow.core.NonEmptyList
 import arrow.optics.optics
-import arrow.test.generators.nonEmptyList
+import helios.arrow.generators.nonEmptyList
 import helios.json
 import helios.test.generators.alphaStr
-import io.kotlintest.properties.Gen
+import io.kotest.properties.Gen
+import io.kotest.properties.bind
+import io.kotest.properties.int
+import io.kotest.properties.list
 
 @json
 @optics

--- a/helios-core/src/test/kotlin/helios/core/model/SampleData.kt
+++ b/helios-core/src/test/kotlin/helios/core/model/SampleData.kt
@@ -1,6 +1,6 @@
 package helios.core.model
 
-import arrow.data.NonEmptyList
+import arrow.core.NonEmptyList
 import arrow.optics.optics
 import arrow.test.generators.nonEmptyList
 import helios.json

--- a/helios-core/src/test/kotlin/helios/instances/EnumTest.kt
+++ b/helios-core/src/test/kotlin/helios/instances/EnumTest.kt
@@ -1,12 +1,12 @@
 package helios.instances
 
-import arrow.test.UnitSpec
+import helios.arrow.UnitSpec
 import helios.core.EnumValueNotFound
 import helios.core.JsInt
 import helios.core.JsString
 import helios.core.JsStringDecodingError
-import io.kotlintest.assertions.arrow.either.shouldBeLeft
-import io.kotlintest.assertions.arrow.either.shouldBeRight
+import io.kotest.assertions.arrow.either.shouldBeLeft
+import io.kotest.assertions.arrow.either.shouldBeRight
 
 private enum class Foo {
   A

--- a/helios-core/src/test/kotlin/helios/instances/InstancesArrowTest.kt
+++ b/helios-core/src/test/kotlin/helios/instances/InstancesArrowTest.kt
@@ -4,7 +4,7 @@ import arrow.core.Either
 import arrow.core.Option
 import arrow.core.Tuple2
 import arrow.core.Tuple3
-import arrow.data.NonEmptyList
+import arrow.core.NonEmptyList
 import arrow.test.UnitSpec
 import arrow.test.generators.*
 import helios.core.JsArray

--- a/helios-core/src/test/kotlin/helios/instances/InstancesArrowTest.kt
+++ b/helios-core/src/test/kotlin/helios/instances/InstancesArrowTest.kt
@@ -5,17 +5,23 @@ import arrow.core.Option
 import arrow.core.Tuple2
 import arrow.core.Tuple3
 import arrow.core.NonEmptyList
-import arrow.test.UnitSpec
-import arrow.test.generators.*
+import helios.arrow.UnitSpec
+import helios.arrow.generators.nonEmptyList
+import helios.arrow.generators.tuple2
+import helios.arrow.generators.tuple3
 import helios.core.JsArray
 import helios.test.generators.alphaStr
 import helios.test.generators.jsBoolean
 import helios.test.generators.jsString
-import io.kotlintest.assertions.arrow.either.beLeft
-import io.kotlintest.assertions.arrow.either.beRight
-import io.kotlintest.properties.Gen
-import io.kotlintest.properties.assertAll
-import io.kotlintest.should
+import io.kotest.assertions.arrow.either.beLeft
+import io.kotest.assertions.arrow.either.beRight
+import io.kotest.assertions.arrow.either.either
+import io.kotest.assertions.arrow.option.option
+import io.kotest.properties.Gen
+import io.kotest.properties.assertAll
+import io.kotest.properties.bool
+import io.kotest.properties.double
+import io.kotest.should
 
 class InstancesArrowTest : UnitSpec() {
   init {

--- a/helios-core/src/test/kotlin/helios/instances/InstancesCollectionsTest.kt
+++ b/helios-core/src/test/kotlin/helios/instances/InstancesCollectionsTest.kt
@@ -1,13 +1,14 @@
 package helios.instances
 
-import arrow.test.UnitSpec
+import helios.arrow.UnitSpec
 import helios.test.generators.*
-import io.kotlintest.assertions.arrow.either.beLeft
-import io.kotlintest.assertions.arrow.either.beRight
-import io.kotlintest.matchers.maps.shouldContainExactly
-import io.kotlintest.properties.Gen
-import io.kotlintest.properties.assertAll
-import io.kotlintest.should
+import helios.test.generators.byte
+import helios.test.generators.short
+import io.kotest.assertions.arrow.either.beLeft
+import io.kotest.assertions.arrow.either.beRight
+import io.kotest.matchers.maps.shouldContainExactly
+import io.kotest.properties.*
+import io.kotest.should
 
 class InstancesCollectionsTest : UnitSpec() {
 

--- a/helios-core/src/test/kotlin/helios/instances/InstancesJavaTest.kt
+++ b/helios-core/src/test/kotlin/helios/instances/InstancesJavaTest.kt
@@ -1,13 +1,15 @@
 package helios.instances
 
-import arrow.test.UnitSpec
+import helios.arrow.UnitSpec
 import helios.test.generators.bigDecimal
 import helios.test.generators.jsString
-import io.kotlintest.assertions.arrow.either.beLeft
-import io.kotlintest.assertions.arrow.either.beRight
-import io.kotlintest.properties.Gen
-import io.kotlintest.properties.assertAll
-import io.kotlintest.should
+import io.kotest.assertions.arrow.either.beLeft
+import io.kotest.assertions.arrow.either.beRight
+import io.kotest.properties.Gen
+import io.kotest.properties.assertAll
+import io.kotest.properties.bigInteger
+import io.kotest.properties.uuid
+import io.kotest.should
 
 class InstancesJavaTest : UnitSpec() {
   init {

--- a/helios-core/src/test/kotlin/helios/instances/InstancesJavaTimeTest.kt
+++ b/helios-core/src/test/kotlin/helios/instances/InstancesJavaTimeTest.kt
@@ -1,12 +1,12 @@
 package helios.instances
 
-import arrow.test.UnitSpec
+import helios.arrow.UnitSpec
 import helios.test.generators.jsBoolean
-import io.kotlintest.assertions.arrow.either.beLeft
-import io.kotlintest.assertions.arrow.either.beRight
-import io.kotlintest.properties.Gen
-import io.kotlintest.properties.assertAll
-import io.kotlintest.should
+import io.kotest.assertions.arrow.either.beLeft
+import io.kotest.assertions.arrow.either.beRight
+import io.kotest.properties.Gen
+import io.kotest.properties.assertAll
+import io.kotest.should
 import java.time.*
 
 class InstancesJavaTimeTest : UnitSpec() {

--- a/helios-core/src/test/kotlin/helios/instances/InstancesTest.kt
+++ b/helios-core/src/test/kotlin/helios/instances/InstancesTest.kt
@@ -1,13 +1,15 @@
 package helios.instances
 
-import arrow.test.UnitSpec
-import arrow.test.generators.intSmall
+import helios.arrow.UnitSpec
+import helios.arrow.generators.intSmall
 import helios.test.generators.*
-import io.kotlintest.assertions.arrow.either.beLeft
-import io.kotlintest.assertions.arrow.either.beRight
-import io.kotlintest.properties.Gen
-import io.kotlintest.properties.assertAll
-import io.kotlintest.should
+import helios.test.generators.byte
+import helios.test.generators.short
+import helios.test.generators.triple
+import io.kotest.assertions.arrow.either.beLeft
+import io.kotest.assertions.arrow.either.beRight
+import io.kotest.properties.*
+import io.kotest.should
 
 class InstancesTest : UnitSpec() {
   init {

--- a/helios-dsl-meta/build.gradle
+++ b/helios-dsl-meta/build.gradle
@@ -11,8 +11,8 @@ dependencies {
     compileOnly "com.google.auto.service:auto-service:$autoServiceVersion"
     kapt "com.google.auto.service:auto-service:$autoServiceVersion"
 
-    testImplementation("io.kotlintest:kotlintest-runner-junit5:$kotlinTestVersion")
-    testImplementation("io.kotlintest:kotlintest-assertions-arrow:$kotlinTestVersion")
+    testImplementation("io.kotest:kotest-runner-junit5:$kotlinTestVersion")
+    testImplementation("io.kotest:kotest-assertions-arrow:$kotlinTestVersion")
     testCompile "com.google.testing.compile:compile-testing:$googleTestingVersion"
     testCompile fileTree(dir: "./src/test/libs", includes: ["*.jar"])
     testCompile files(Jvm.current().getToolsJar())

--- a/helios-integrations/helios-retrofit/build.gradle
+++ b/helios-integrations/helios-retrofit/build.gradle
@@ -11,9 +11,8 @@ dependencies {
     compile "com.squareup.retrofit2:retrofit:$retrofitVersion"
 
     testImplementation("com.squareup.okhttp3:mockwebserver:$mockwebserverVersion")
-    testImplementation("io.arrow-kt:arrow-test:$arrowVersion")
-    testImplementation("io.kotlintest:kotlintest-runner-junit5:$kotlinTestVersion")
-    testImplementation("io.kotlintest:kotlintest-assertions-arrow:$kotlinTestVersion")
+    testImplementation("io.kotest:kotest-runner-junit5:$kotlinTestVersion")
+    testImplementation("io.kotest:kotest-assertions-arrow:$kotlinTestVersion")
 
     kaptTest project(":helios-meta")
     

--- a/helios-integrations/helios-retrofit/src/main/kotlin/helios/retrofit/HeliosConverterFactory.kt
+++ b/helios-integrations/helios-retrofit/src/main/kotlin/helios/retrofit/HeliosConverterFactory.kt
@@ -3,7 +3,6 @@ package helios.retrofit
 import arrow.core.Option
 import arrow.core.getOrElse
 import arrow.core.toOption
-import arrow.data.extensions.list.monad.map
 import helios.typeclasses.Decoder
 import helios.typeclasses.Encoder
 import okhttp3.RequestBody

--- a/helios-integrations/helios-retrofit/src/test/kotlin/helios/retrofit/HeliosConverterFactoryTest.kt
+++ b/helios-integrations/helios-retrofit/src/test/kotlin/helios/retrofit/HeliosConverterFactoryTest.kt
@@ -2,10 +2,10 @@ package helios.retrofit
 
 import arrow.core.Try
 import arrow.core.Tuple3
-import io.kotlintest.Description
-import io.kotlintest.shouldBe
-import io.kotlintest.shouldNotBe
-import io.kotlintest.specs.StringSpec
+import io.kotest.Description
+import io.kotest.shouldBe
+import io.kotest.shouldNotBe
+import io.kotest.specs.StringSpec
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.Rule

--- a/helios-meta/build.gradle
+++ b/helios-meta/build.gradle
@@ -11,8 +11,8 @@ dependencies {
     compileOnly "com.google.auto.service:auto-service:$autoServiceVersion"
     kapt "com.google.auto.service:auto-service:$autoServiceVersion"
 
-    testImplementation("io.kotlintest:kotlintest-runner-junit5:$kotlinTestVersion")
-    testImplementation("io.kotlintest:kotlintest-assertions-arrow:$kotlinTestVersion")
+    testImplementation("io.kotest:kotest-runner-junit5:$kotlinTestVersion")
+    testImplementation("io.kotest:kotest-assertions-arrow:$kotlinTestVersion")
     testCompile "com.google.testing.compile:compile-testing:$googleTestingVersion"
     testCompile fileTree(dir: "./src/test/libs", includes: ["*.jar"])
     testCompile files(Jvm.current().getToolsJar())

--- a/helios-optics/build.gradle
+++ b/helios-optics/build.gradle
@@ -8,7 +8,6 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
 
     compile "io.arrow-kt:arrow-optics:$arrowVersion"
-    compile "io.arrow-kt:arrow-typeclasses:$arrowVersion"
 
     kapt "io.arrow-kt:arrow-meta:$arrowVersion"
     kapt project(":helios-meta")

--- a/helios-optics/build.gradle
+++ b/helios-optics/build.gradle
@@ -12,9 +12,8 @@ dependencies {
     kapt "io.arrow-kt:arrow-meta:$arrowVersion"
     kapt project(":helios-meta")
 
-    testImplementation("io.arrow-kt:arrow-test:$arrowVersion")
-    testImplementation("io.kotlintest:kotlintest-runner-junit5:$kotlinTestVersion")
-    testImplementation("io.kotlintest:kotlintest-assertions-arrow:$kotlinTestVersion")
+    testImplementation("io.kotest:kotest-runner-junit5:$kotlinTestVersion")
+    testImplementation("io.kotest:kotest-assertions-arrow:$kotlinTestVersion")
 
     kaptTest project(":helios-meta")
     kaptTest "io.arrow-kt:arrow-meta:$arrowVersion"

--- a/helios-optics/src/main/kotlin/helios/optics/JsonPath.kt
+++ b/helios-optics/src/main/kotlin/helios/optics/JsonPath.kt
@@ -8,7 +8,7 @@ import arrow.optics.Optional
 import arrow.optics.Prism
 import arrow.optics.dsl.at
 import arrow.optics.extensions.ListFilterIndex
-import arrow.optics.extensions.MapFilterIndex
+import arrow.optics.extensions.filterMapIndex
 import helios.core.*
 import helios.instances.decoder
 import helios.instances.encoder
@@ -144,7 +144,7 @@ fun Optional<Json, Json>.filterIndex(p: Predicate<Int>) =
  * Filter [JsObject] by keys that satisfy the predicate [p].
  */
 fun Optional<Json, Json>.filterKeys(p: Predicate<String>) =
-  `object` compose MapFilterIndex<String, Json>().filter(p)
+  `object` compose filterMapIndex<String, Json>().filter(p)
 
 /**
  * Unsafe optic: needs some investigation because it is required to extract reasonable typed values from Json.

--- a/helios-optics/src/main/kotlin/helios/optics/JsonTraversalPath.kt
+++ b/helios-optics/src/main/kotlin/helios/optics/JsonTraversalPath.kt
@@ -8,7 +8,7 @@ import arrow.optics.PTraversal
 import arrow.optics.Traversal
 import arrow.optics.dsl.at
 import arrow.optics.extensions.ListFilterIndex
-import arrow.optics.extensions.MapFilterIndex
+import arrow.optics.extensions.filterMapIndex
 import helios.core.*
 import helios.instances.decoder
 import helios.instances.encoder
@@ -131,4 +131,4 @@ fun Traversal<Json, Json>.filterIndex(p: Predicate<Int>): PTraversal<Json, Json,
  * Filter [JsObject] by keys that satisfy the predicate [p].
  */
 fun Traversal<Json, Json>.filterKeys(p: Predicate<String>): PTraversal<Json, Json, Json, Json> =
-  `object` compose MapFilterIndex<String, Json>().filter(p)
+  `object` compose filterMapIndex<String, Json>().filter(p)

--- a/helios-optics/src/main/kotlin/helios/optics/instances.kt
+++ b/helios-optics/src/main/kotlin/helios/optics/instances.kt
@@ -1,11 +1,7 @@
 package helios.optics
 
 import arrow.Kind
-import arrow.core.Option
-import arrow.core.left
-import arrow.core.right
-import arrow.data.getOption
-import arrow.data.k
+import arrow.core.*
 import arrow.extension
 import arrow.optics.Lens
 import arrow.optics.Optional

--- a/helios-optics/src/main/kotlin/helios/optics/optics.kt
+++ b/helios-optics/src/main/kotlin/helios/optics/optics.kt
@@ -17,7 +17,7 @@ import helios.optics.jsarray.each.each
 import helios.optics.jsobject.each.each
 
 private fun <S, A : S> PPrism.Companion.fromOption(getOption: (S) -> Option<A>): Prism<S, A> =
-  Prism({ s: S -> getOption(s).toEither { s } }, ::identity)
+  Prism({ s: S -> getOption(s) }, ::identity)
 
 @PublishedApi
 internal val boolean = Prism.fromOption<Json, JsBoolean>(Json::asJsBoolean)

--- a/helios-optics/src/test/kotlin/helios/optics/JsonDSLTest.kt
+++ b/helios-optics/src/test/kotlin/helios/optics/JsonDSLTest.kt
@@ -4,17 +4,17 @@ import arrow.core.Option
 import arrow.core.extensions.option.eq.eq
 import arrow.core.identity
 import arrow.core.some
-import arrow.test.UnitSpec
-import arrow.test.generators.functionAToB
-import arrow.test.laws.PrismLaws
 import arrow.typeclasses.Eq
+import helios.arrow.UnitSpec
+import helios.arrow.generators.functionAToB
+import helios.arrow.laws.PrismLaws
 import helios.core.JsFalse
 import helios.core.JsString
 import helios.core.Json
 import helios.test.generators.*
-import io.kotlintest.assertions.arrow.option.shouldBeNone
-import io.kotlintest.properties.Gen
-import io.kotlintest.properties.forAll
+import io.kotest.assertions.arrow.option.shouldBeNone
+import io.kotest.properties.Gen
+import io.kotest.properties.forAll
 
 class JsonDSLTest : UnitSpec() {
 

--- a/helios-optics/src/test/kotlin/helios/optics/OpticsTest.kt
+++ b/helios-optics/src/test/kotlin/helios/optics/OpticsTest.kt
@@ -1,13 +1,13 @@
 package helios.optics
 
 import arrow.core.identity
-import arrow.test.UnitSpec
+import helios.arrow.UnitSpec
 import helios.core.*
 import helios.instances.jsnumber.eq.eq
 import helios.instances.json.eq.eq
-import io.kotlintest.assertions.arrow.option.shouldBeNone
-import io.kotlintest.assertions.arrow.option.shouldBeSome
-import io.kotlintest.shouldBe
+import io.kotest.assertions.arrow.option.shouldBeNone
+import io.kotest.assertions.arrow.option.shouldBeSome
+import io.kotest.shouldBe
 
 class OpticsTest : UnitSpec() {
 

--- a/helios-optics/src/test/kotlin/helios/optics/domain.kt
+++ b/helios-optics/src/test/kotlin/helios/optics/domain.kt
@@ -2,7 +2,8 @@ package helios.optics
 
 import helios.json
 import helios.test.generators.alphaStr
-import io.kotlintest.properties.Gen
+import io.kotest.properties.Gen
+import io.kotest.properties.list
 
 @json
 data class City(val streets: List<Street>) {

--- a/helios-optics/src/test/kotlin/helios/optics/instances.kt
+++ b/helios-optics/src/test/kotlin/helios/optics/instances.kt
@@ -3,12 +3,12 @@ package helios.optics
 import arrow.core.None
 import arrow.core.Option
 import arrow.core.extensions.option.eq.eq
-import arrow.test.UnitSpec
-import arrow.test.generators.functionAToB
-import arrow.test.generators.option
-import arrow.test.laws.LensLaws
-import arrow.test.laws.OptionalLaws
-import arrow.test.laws.TraversalLaws
+import helios.arrow.UnitSpec
+import helios.arrow.generators.functionAToB
+import helios.arrow.generators.option
+import helios.arrow.laws.LensLaws
+import helios.arrow.laws.OptionalLaws
+import helios.arrow.laws.TraversalLaws
 import arrow.typeclasses.Eq
 import arrow.typeclasses.Monoid
 import helios.core.JsArray
@@ -25,7 +25,7 @@ import helios.test.generators.alphaStr
 import helios.test.generators.jsArray
 import helios.test.generators.jsObject
 import helios.test.generators.json
-import io.kotlintest.properties.Gen
+import io.kotest.properties.Gen
 
 class InstancesTest : UnitSpec() {
 

--- a/helios-parser/build.gradle
+++ b/helios-parser/build.gradle
@@ -1,7 +1,6 @@
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     compile "io.arrow-kt:arrow-core-data:$arrowVersion"
-    compile "io.arrow-kt:arrow-core-extensions:$arrowVersion"
 }
 
 apply from: rootProject.file("gradle/generated-kotlin-sources.gradle")

--- a/helios-samples/retrofit-sample/build.gradle
+++ b/helios-samples/retrofit-sample/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     compile "com.squareup.retrofit2:retrofit:$retrofitVersion"
-    compile "io.arrow-kt:arrow-effects-data:$arrowVersion"
+    compile "io.arrow-kt:arrow-fx:$arrowVersion"
 
     kapt project(':helios-meta')
     kapt project(':helios-dsl-meta')

--- a/helios-samples/retrofit-sample/src/main/kotlin/helios/sample/retrofit/Sample.kt
+++ b/helios-samples/retrofit-sample/src/main/kotlin/helios/sample/retrofit/Sample.kt
@@ -1,6 +1,6 @@
 package helios.sample.retrofit
 
-import arrow.effects.IO
+import arrow.fx.IO
 import helios.retrofit.HeliosConverterFactory
 import helios.retrofit.JsonableEvidence
 import retrofit2.Retrofit

--- a/helios-test/build.gradle
+++ b/helios-test/build.gradle
@@ -1,8 +1,8 @@
-
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
-    compile "io.arrow-kt:arrow-test:$arrowVersion"
-
+    compile("io.kotest:kotest-runner-junit5:$kotlinTestVersion")
+    compile("io.kotest:kotest-assertions-arrow:$kotlinTestVersion")
+    compile "io.arrow-kt:arrow-optics:$arrowVersion"
     compile project(":helios-core")
 }
 

--- a/helios-test/src/main/kotlin/helios/arrow/UnitSpec.kt
+++ b/helios-test/src/main/kotlin/helios/arrow/UnitSpec.kt
@@ -1,0 +1,26 @@
+package helios.arrow
+
+import helios.arrow.laws.Law
+import io.kotest.TestCase
+import io.kotest.TestType
+import io.kotest.specs.StringSpec
+
+
+/**
+ * Base class for unit tests
+ */
+abstract class UnitSpec : StringSpec() {
+
+    private val lawTestCases = mutableListOf<TestCase>()
+
+    fun testLaws(vararg laws: List<Law>): List<TestCase> = laws
+        .flatMap { list: List<Law> -> list.asIterable() }
+        .distinctBy { law: Law -> law.name }
+        .map { law: Law ->
+            val lawTestCase = createTestCase(law.name, law.test, defaultTestCaseConfig, TestType.Test)
+            lawTestCases.add(lawTestCase)
+            lawTestCase
+        }
+
+    override fun testCases(): List<TestCase> = super.testCases() + lawTestCases
+}

--- a/helios-test/src/main/kotlin/helios/arrow/generators/Generators.kt
+++ b/helios-test/src/main/kotlin/helios/arrow/generators/Generators.kt
@@ -1,0 +1,152 @@
+package helios.arrow.generators
+
+
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.core.Failure
+import arrow.core.Left
+import arrow.core.ListK
+import arrow.core.MapK
+import arrow.core.NonEmptyList
+import arrow.core.Option
+import arrow.core.Right
+import arrow.core.SequenceK
+import arrow.core.SetK
+import arrow.core.SortedMapK
+import arrow.core.Success
+import arrow.core.Try
+import arrow.core.Tuple10
+import arrow.core.Tuple2
+import arrow.core.Tuple3
+import arrow.core.Tuple4
+import arrow.core.Tuple5
+import arrow.core.Tuple6
+import arrow.core.Tuple7
+import arrow.core.Tuple8
+import arrow.core.Tuple9
+import arrow.core.Validated
+import arrow.core.k
+import arrow.core.toOption
+import arrow.typeclasses.Applicative
+import arrow.typeclasses.ApplicativeError
+import io.kotest.properties.*
+import java.util.concurrent.TimeUnit
+
+fun Gen.Companion.short(): Gen<Short> =
+    Gen.choose(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt()).map { it.toShort() }
+
+fun Gen.Companion.byte(): Gen<Byte> =
+    Gen.choose(Byte.MIN_VALUE.toInt(), Byte.MAX_VALUE.toInt()).map { it.toByte() }
+
+fun <F, A> Gen<A>.applicative(AP: Applicative<F>): Gen<Kind<F, A>> =
+    map { AP.just(it) }
+
+fun <F, A, E> Gen.Companion.applicativeError(genA: Gen<A>, errorGen: Gen<E>, AP: ApplicativeError<F, E>): Gen<Kind<F, A>> =
+    Gen.oneOf<Either<E, A>>(genA.map(::Right), errorGen.map(::Left)).map {
+        it.fold(AP::raiseError, AP::just)
+    }
+
+fun <F, A> Gen<A>.applicativeError(AP: ApplicativeError<F, Throwable>): Gen<Kind<F, A>> =
+    Gen.applicativeError(this, Gen.throwable(), AP)
+
+fun <A, B> Gen.Companion.functionAToB(gen: Gen<B>): Gen<(A) -> B> = gen.map { b: B -> { _: A -> b } }
+
+fun <A> Gen.Companion.functionAAToA(gen: Gen<A>): Gen<(A, A) -> A> = gen.map { a: A -> { _: A, _: A -> a } }
+
+fun Gen.Companion.throwable(): Gen<Throwable> = Gen.from(listOf(RuntimeException(), NoSuchElementException(), IllegalArgumentException()))
+
+fun Gen.Companion.fatalThrowable(): Gen<Throwable> = Gen.from(listOf(ThreadDeath(), StackOverflowError(), OutOfMemoryError(), InterruptedException()))
+
+fun Gen.Companion.intSmall(): Gen<Int> = Gen.oneOf(Gen.choose(Int.MIN_VALUE / 10000, -1), Gen.choose(0, Int.MAX_VALUE / 10000))
+
+fun <A, B> Gen.Companion.tuple2(genA: Gen<A>, genB: Gen<B>): Gen<Tuple2<A, B>> = Gen.bind(genA, genB) { a: A, b: B -> Tuple2(a, b) }
+
+fun <A, B, C> Gen.Companion.tuple3(genA: Gen<A>, genB: Gen<B>, genC: Gen<C>): Gen<Tuple3<A, B, C>> =
+    Gen.bind(genA, genB, genC) { a: A, b: B, c: C -> Tuple3(a, b, c) }
+
+fun <A, B, C, D> Gen.Companion.tuple4(genA: Gen<A>, genB: Gen<B>, genC: Gen<C>, genD: Gen<D>): Gen<Tuple4<A, B, C, D>> =
+    Gen.bind(genA, genB, genC, genD) { a: A, b: B, c: C, d: D -> Tuple4(a, b, c, d) }
+
+fun <A, B, C, D, E> Gen.Companion.tuple5(genA: Gen<A>, genB: Gen<B>, genC: Gen<C>, genD: Gen<D>, genE: Gen<E>): Gen<Tuple5<A, B, C, D, E>> =
+    Gen.bind(genA, genB, genC, genD, genE) { a: A, b: B, c: C, d: D, e: E -> Tuple5(a, b, c, d, e) }
+
+fun <A, B, C, D, E, F> Gen.Companion.tuple6(genA: Gen<A>, genB: Gen<B>, genC: Gen<C>, genD: Gen<D>, genE: Gen<E>, genF: Gen<F>): Gen<Tuple6<A, B, C, D, E, F>> =
+    Gen.bind(genA, genB, genC, genD, genE, genF) { a: A, b: B, c: C, d: D, e: E, f: F -> Tuple6(a, b, c, d, e, f) }
+
+fun <A, B, C, D, E, F, G> Gen.Companion.tuple7(genA: Gen<A>, genB: Gen<B>, genC: Gen<C>, genD: Gen<D>, genE: Gen<E>, genF: Gen<F>, genG: Gen<G>): Gen<Tuple7<A, B, C, D, E, F, G>> =
+    Gen.bind(genA, genB, genC, genD, genE, genF, genG) { a: A, b: B, c: C, d: D, e: E, f: F, g: G -> Tuple7(a, b, c, d, e, f, g) }
+
+fun <A, B, C, D, E, F, G, H> Gen.Companion.tuple8(genA: Gen<A>, genB: Gen<B>, genC: Gen<C>, genD: Gen<D>, genE: Gen<E>, genF: Gen<F>, genG: Gen<G>, genH: Gen<H>): Gen<Tuple8<A, B, C, D, E, F, G, H>> =
+    Gen.bind(Gen.tuple7(genA, genB, genC, genD, genE, genF, genG), genH) { tuple: Tuple7<A, B, C, D, E, F, G>, h: H -> Tuple8(tuple.a, tuple.b, tuple.c, tuple.d, tuple.e, tuple.f, tuple.g, h) }
+
+fun <A, B, C, D, E, F, G, H, I> Gen.Companion.tuple9(genA: Gen<A>, genB: Gen<B>, genC: Gen<C>, genD: Gen<D>, genE: Gen<E>, genF: Gen<F>, genG: Gen<G>, genH: Gen<H>, genI: Gen<I>): Gen<Tuple9<A, B, C, D, E, F, G, H, I>> =
+    Gen.bind(Gen.tuple8(genA, genB, genC, genD, genE, genF, genG, genH), genI) { tuple: Tuple8<A, B, C, D, E, F, G, H>, i: I -> Tuple9(tuple.a, tuple.b, tuple.c, tuple.d, tuple.e, tuple.f, tuple.g, tuple.h, i) }
+
+fun <A, B, C, D, E, F, G, H, I, J> Gen.Companion.tuple10(genA: Gen<A>, genB: Gen<B>, genC: Gen<C>, genD: Gen<D>, genE: Gen<E>, genF: Gen<F>, genG: Gen<G>, genH: Gen<H>, genI: Gen<I>, genJ: Gen<J>): Gen<Tuple10<A, B, C, D, E, F, G, H, I, J>> =
+    Gen.bind(Gen.tuple9(genA, genB, genC, genD, genE, genF, genG, genH, genI), genJ) { tuple: Tuple9<A, B, C, D, E, F, G, H, I>, j: J -> Tuple10(tuple.a, tuple.b, tuple.c, tuple.d, tuple.e, tuple.f, tuple.g, tuple.h, tuple.i, j) }
+
+fun Gen.Companion.nonZeroInt(): Gen<Int> = Gen.int().filter { it != 0 }
+
+fun Gen.Companion.lessThan(max: Int): Gen<Int> = Gen.int().filter { it < max }
+
+fun Gen.Companion.lessEqual(max: Int): Gen<Int> = Gen.int().filter { it <= max }
+
+fun Gen.Companion.greaterThan(min: Int): Gen<Int> = Gen.int().filter { it > min }
+
+fun Gen.Companion.greaterEqual(min: Int): Gen<Int> = Gen.int().filter { it >= min }
+
+fun Gen.Companion.greaterOrEqThan(max: Int): Gen<Int> = Gen.int().filter { it >= max }
+
+fun Gen.Companion.intPredicate(): Gen<(Int) -> Boolean> =
+    Gen.nonZeroInt().flatMap { num ->
+        val absNum = Math.abs(num)
+        Gen.from(listOf<(Int) -> Boolean>(
+            { it > num },
+            { it <= num },
+            { it % absNum == 0 },
+            { it % absNum == absNum - 1 })
+        )
+    }
+
+fun <B> Gen.Companion.option(gen: Gen<B>): Gen<Option<B>> =
+    gen.orNull().map { it.toOption() }
+
+fun <E, A> Gen.Companion.either(genE: Gen<E>, genA: Gen<A>): Gen<Either<E, A>> {
+    val genLeft = genE.map<Either<E, A>> { Left(it) }
+    val genRight = genA.map<Either<E, A>> { Right(it) }
+    return Gen.oneOf(genLeft, genRight)
+}
+
+fun <E, A> Gen<E>.or(genA: Gen<A>): Gen<Either<E, A>> = Gen.either(this, genA)
+
+fun <E, A> Gen.Companion.validated(genE: Gen<E>, genA: Gen<A>): Gen<Validated<E, A>> =
+    Gen.either(genE, genA).map { Validated.fromEither(it) }
+
+fun <A> Gen.Companion.`try`(genA: Gen<A>, genThrowable: Gen<Throwable> = throwable()): Gen<Try<A>> =
+    Gen.either(genThrowable, genA).map { it.fold({ Failure(it) }, { Success(it) }) }
+
+fun <A> Gen.Companion.nonEmptyList(gen: Gen<A>): Gen<NonEmptyList<A>> =
+    gen.flatMap { head -> Gen.list(gen).map { NonEmptyList(head, it) } }
+
+fun <K : Comparable<K>, V> Gen.Companion.sortedMapK(genK: Gen<K>, genV: Gen<V>): Gen<SortedMapK<K, V>> =
+    Gen.bind(genK, genV) { k: K, v: V -> sortedMapOf(k to v) }.map { it.k() }
+
+fun <K, V> Gen.Companion.mapK(genK: Gen<K>, genV: Gen<V>): Gen<MapK<K, V>> =
+    Gen.map(genK, genV).map { it.k() }
+
+fun Gen.Companion.timeUnit(): Gen<TimeUnit> = Gen.from(TimeUnit.values())
+
+fun <A> Gen.Companion.listK(genA: Gen<A>): Gen<ListK<A>> = Gen.list(genA).map { it.k() }
+
+fun <A> Gen.Companion.sequenceK(genA: Gen<A>): Gen<SequenceK<A>> = Gen.list(genA).map { it.asSequence().k() }
+
+fun Gen.Companion.nonEmptyString(): Gen<String> = Gen.string().filter { it.isNotEmpty() }
+
+fun Gen.Companion.char(): Gen<Char> =
+    Gen.from(('A'..'Z') + ('a'..'z') + ('0'..'9') + "!@#$%%^&*()_-~`,<.?/:;}{][±§".toList())
+
+fun <A> Gen.Companion.genSetK(genA: Gen<A>): Gen<SetK<A>> = Gen.set(genA).map { it.k() }
+
+fun Gen.Companion.unit(): Gen<Unit> =
+    create { Unit }

--- a/helios-test/src/main/kotlin/helios/arrow/laws/Law.kt
+++ b/helios-test/src/main/kotlin/helios/arrow/laws/Law.kt
@@ -1,7 +1,5 @@
 package helios.arrow.laws
 
-
-
 import arrow.typeclasses.Eq
 import helios.arrow.generators.tuple2
 import helios.arrow.generators.tuple3

--- a/helios-test/src/main/kotlin/helios/arrow/laws/Law.kt
+++ b/helios-test/src/main/kotlin/helios/arrow/laws/Law.kt
@@ -1,0 +1,71 @@
+package helios.arrow.laws
+
+
+
+import arrow.typeclasses.Eq
+import helios.arrow.generators.tuple2
+import helios.arrow.generators.tuple3
+import helios.arrow.generators.tuple4
+import helios.arrow.generators.tuple5
+import io.kotest.Matcher
+import io.kotest.MatcherResult
+import io.kotest.core.TestContext
+import io.kotest.properties.Gen
+import io.kotest.should
+
+fun throwableEq() = Eq { a: Throwable, b ->
+    a::class == b::class && a.message == b.message
+}
+
+data class Law(val name: String, val test: suspend TestContext.() -> Unit)
+
+fun <A> A.equalUnderTheLaw(b: A, eq: Eq<A>): Boolean =
+    eq.run { eqv(b) }
+
+fun <A> A.shouldBeEq(b: A, eq: Eq<A>): Unit = this should matchUnderEq(eq, b)
+
+fun <A> matchUnderEq(eq: Eq<A>, b: A) = object : Matcher<A> {
+    override fun test(value: A): MatcherResult {
+        return MatcherResult(eq.run { value.eqv(b) }, "Expected: $b but found: $value", "$b and $value should be equal")
+    }
+}
+
+fun <A> forFew(amount: Int, gena: Gen<A>, fn: (a: A) -> Boolean) {
+    gena.random().take(amount).toList().map {
+        if (!fn(it)) {
+            throw AssertionError("Property failed for\n$it)")
+        }
+    }
+}
+
+fun <A, B> forFew(amount: Int, gena: Gen<A>, genb: Gen<B>, fn: (a: A, b: B) -> Boolean) {
+    Gen.tuple2(gena, genb).random().take(amount).toList().map {
+        if (!fn(it.a, it.b)) {
+            throw AssertionError("Property failed for\n${it.a}\n${it.b})")
+        }
+    }
+}
+
+fun <A, B, C> forFew(amount: Int, gena: Gen<A>, genb: Gen<B>, genc: Gen<C>, fn: (a: A, b: B, c: C) -> Boolean) {
+    Gen.tuple3(gena, genb, genc).random().take(amount).toList().map {
+        if (!fn(it.a, it.b, it.c)) {
+            throw AssertionError("Property failed for\n${it.a}\n${it.b}\n${it.c})")
+        }
+    }
+}
+
+fun <A, B, C, D> forFew(amount: Int, gena: Gen<A>, genb: Gen<B>, genc: Gen<C>, gend: Gen<D>, fn: (a: A, b: B, c: C, d: D) -> Boolean) {
+    Gen.tuple4(gena, genb, genc, gend).random().take(amount).toList().map {
+        if (!fn(it.a, it.b, it.c, it.d)) {
+            throw AssertionError("Property failed for\n${it.a}\n${it.b}\n${it.c}\n${it.d})")
+        }
+    }
+}
+
+fun <A, B, C, D, E> forFew(amount: Int, gena: Gen<A>, genb: Gen<B>, genc: Gen<C>, gend: Gen<D>, gene: Gen<E>, fn: (a: A, b: B, c: C, d: D, e: E) -> Boolean) {
+    Gen.tuple5(gena, genb, genc, gend, gene).random().take(amount).toList().map {
+        if (!fn(it.a, it.b, it.c, it.d, it.e)) {
+            throw AssertionError("Property failed for\n${it.a}\n${it.b}\n${it.c}\n${it.d}\n${it.e})")
+        }
+    }
+}

--- a/helios-test/src/main/kotlin/helios/arrow/laws/LensLaws.kt
+++ b/helios-test/src/main/kotlin/helios/arrow/laws/LensLaws.kt
@@ -1,16 +1,11 @@
 package helios.arrow.laws
 
-import arrow.core.Id
-import arrow.core.compose
+import arrow.core.*
 import arrow.core.extensions.const.applicative.applicative
 import arrow.core.extensions.id.functor.functor
-import arrow.core.identity
-import arrow.core.value
 import arrow.optics.Lens
-import arrow.typeclasses.Const
 import arrow.typeclasses.Eq
 import arrow.typeclasses.Monoid
-import arrow.typeclasses.value
 import io.kotest.properties.Gen
 import io.kotest.properties.constant
 import io.kotest.properties.forAll

--- a/helios-test/src/main/kotlin/helios/arrow/laws/LensLaws.kt
+++ b/helios-test/src/main/kotlin/helios/arrow/laws/LensLaws.kt
@@ -1,0 +1,151 @@
+package helios.arrow.laws
+
+import arrow.core.Id
+import arrow.core.compose
+import arrow.core.extensions.const.applicative.applicative
+import arrow.core.extensions.id.functor.functor
+import arrow.core.identity
+import arrow.core.value
+import arrow.optics.Lens
+import arrow.typeclasses.Const
+import arrow.typeclasses.Eq
+import arrow.typeclasses.Monoid
+import arrow.typeclasses.value
+import io.kotest.properties.Gen
+import io.kotest.properties.constant
+import io.kotest.properties.forAll
+
+object LensLaws {
+
+  fun <A, B> laws(
+    lensGen: Gen<Lens<A, B>>,
+    aGen: Gen<A>,
+    bGen: Gen<B>,
+    funcGen: Gen<(B) -> B>,
+    EQA: Eq<A>,
+    EQB: Eq<B>,
+    MB: Monoid<B>
+  ): List<Law> =
+    listOf(
+      Law("Lens law: get set") { lensGetSet(lensGen, aGen, EQA) },
+      Law("Lens law: set get") { lensSetGet(lensGen, aGen, bGen, EQB) },
+      Law("Lens law: is set idempotent") {
+        lensSetIdempotent(
+          lensGen,
+          aGen,
+          bGen,
+          EQA
+        )
+      },
+      Law("Lens law: modify identity") {
+        lensModifyIdentity(
+          lensGen,
+          aGen,
+          EQA
+        )
+      },
+      Law("Lens law: compose modify") {
+        lensComposeModify(
+          lensGen,
+          aGen,
+          funcGen,
+          EQA
+        )
+      },
+      Law("Lens law: consistent set modify") {
+        lensConsistentSetModify(
+          lensGen,
+          aGen,
+          bGen,
+          EQA
+        )
+      },
+      Law("Lens law: consistent modify modify id") {
+        lensConsistentModifyModifyId(
+          lensGen,
+          aGen,
+          funcGen,
+          EQA
+        )
+      },
+      Law("Lens law: consistent get modify id") {
+        lensConsistentGetModifyid(
+          lensGen,
+          aGen,
+          EQB,
+          MB
+        )
+      }
+    )
+
+  /**
+   * Warning: Use only when a `Gen.constant()` applies
+   */
+  fun <A, B> laws(
+    lens: Lens<A, B>,
+    aGen: Gen<A>,
+    bGen: Gen<B>,
+    funcGen: Gen<(B) -> B>,
+    EQA: Eq<A>,
+    EQB: Eq<B>,
+    MB: Monoid<B>
+  ): List<Law> = laws(Gen.constant(lens), aGen, bGen, funcGen, EQA, EQB, MB)
+
+  fun <A, B> lensGetSet(lensGen: Gen<Lens<A, B>>, aGen: Gen<A>, EQA: Eq<A>) =
+    forAll(lensGen, aGen) { lens, a ->
+      lens.run {
+        set(a, get(a)).equalUnderTheLaw(a, EQA)
+      }
+    }
+
+  fun <A, B> lensSetGet(lensGen: Gen<Lens<A, B>>, aGen: Gen<A>, bGen: Gen<B>, EQB: Eq<B>) =
+    forAll(lensGen, aGen, bGen) { lens, a, b ->
+      lens.run {
+        get(set(a, b)).equalUnderTheLaw(b, EQB)
+      }
+    }
+
+  fun <A, B> lensSetIdempotent(lensGen: Gen<Lens<A, B>>, aGen: Gen<A>, bGen: Gen<B>, EQA: Eq<A>) =
+    forAll(lensGen, aGen, bGen) { lens, a, b ->
+      lens.run {
+        set(set(a, b), b).equalUnderTheLaw(set(a, b), EQA)
+      }
+    }
+
+  fun <A, B> lensModifyIdentity(lensGen: Gen<Lens<A, B>>, aGen: Gen<A>, EQA: Eq<A>) =
+    forAll(lensGen, aGen) { lens, a ->
+      lens.run {
+        modify(a, ::identity).equalUnderTheLaw(a, EQA)
+      }
+    }
+
+  fun <A, B> lensComposeModify(lensGen: Gen<Lens<A, B>>, aGen: Gen<A>, funcGen: Gen<(B) -> B>, EQA: Eq<A>) =
+    forAll(lensGen, aGen, funcGen, funcGen) { lens, a, f, g ->
+      lens.run {
+        modify(modify(a, f), g).equalUnderTheLaw(modify(a, g compose f), EQA)
+      }
+    }
+
+  fun <A, B> lensConsistentSetModify(lensGen: Gen<Lens<A, B>>, aGen: Gen<A>, bGen: Gen<B>, EQA: Eq<A>) =
+    forAll(lensGen, aGen, bGen) { lens, a, b ->
+      lens.run {
+        set(a, b).equalUnderTheLaw(modify(a) { b }, EQA)
+      }
+    }
+
+  fun <A, B> lensConsistentModifyModifyId(lensGen: Gen<Lens<A, B>>, aGen: Gen<A>, funcGen: Gen<(B) -> B>, EQA: Eq<A>) =
+    forAll(lensGen, aGen, funcGen) { lens, a, f ->
+      lens.run {
+        modify(a, f)
+          .equalUnderTheLaw(modifyF(Id.functor(), a) { Id.just(f(it)) }.value(), EQA)
+      }
+    }
+
+  fun <A, B> lensConsistentGetModifyid(lensGen: Gen<Lens<A, B>>, aGen: Gen<A>, EQB: Eq<B>, MA: Monoid<B>) =
+    forAll(lensGen, aGen) { lens, a ->
+      lens.run {
+        get(a)
+          .equalUnderTheLaw(modifyF(Const.applicative(MA), a, ::Const).value(), EQB)
+      }
+    }
+}

--- a/helios-test/src/main/kotlin/helios/arrow/laws/OptionalLaws.kt
+++ b/helios-test/src/main/kotlin/helios/arrow/laws/OptionalLaws.kt
@@ -1,19 +1,11 @@
 package helios.arrow.laws
 
-import arrow.core.Id
-import arrow.core.None
-import arrow.core.Option
-import arrow.core.Some
-import arrow.core.compose
-import arrow.core.identity
-import arrow.core.value
+import arrow.core.*
 import arrow.core.extensions.const.applicative.applicative
 import arrow.core.extensions.id.applicative.applicative
 import arrow.optics.Optional
-import arrow.typeclasses.Const
 import arrow.typeclasses.Eq
 import arrow.typeclasses.Monoid
-import arrow.typeclasses.value
 import io.kotest.properties.Gen
 import io.kotest.properties.forAll
 import io.kotest.properties.constant

--- a/helios-test/src/main/kotlin/helios/arrow/laws/OptionalLaws.kt
+++ b/helios-test/src/main/kotlin/helios/arrow/laws/OptionalLaws.kt
@@ -1,0 +1,196 @@
+package helios.arrow.laws
+
+import arrow.core.Id
+import arrow.core.None
+import arrow.core.Option
+import arrow.core.Some
+import arrow.core.compose
+import arrow.core.identity
+import arrow.core.value
+import arrow.core.extensions.const.applicative.applicative
+import arrow.core.extensions.id.applicative.applicative
+import arrow.optics.Optional
+import arrow.typeclasses.Const
+import arrow.typeclasses.Eq
+import arrow.typeclasses.Monoid
+import arrow.typeclasses.value
+import io.kotest.properties.Gen
+import io.kotest.properties.forAll
+import io.kotest.properties.constant
+
+object OptionalLaws {
+
+  fun <A, B> laws(
+    optionalGen: Gen<Optional<A, B>>,
+    aGen: Gen<A>,
+    bGen: Gen<B>,
+    funcGen: Gen<(B) -> B>,
+    EQA: Eq<A>,
+    EQOptionB: Eq<Option<B>>
+  ): List<Law> = listOf(
+    Law("Optional Law: set what you get") {
+      getOptionSet(
+        optionalGen,
+        aGen,
+        EQA
+      )
+    },
+    Law("Optional Law: set what you get") {
+      setGetOption(
+        optionalGen,
+        aGen,
+        bGen,
+        EQOptionB
+      )
+    },
+    Law("Optional Law: set is idempotent") {
+      setIdempotent(
+        optionalGen,
+        aGen,
+        bGen,
+        EQA
+      )
+    },
+    Law("Optional Law: modify identity = identity") {
+      modifyIdentity(
+        optionalGen,
+        aGen,
+        EQA
+      )
+    },
+    Law("Optional Law: compose modify") {
+      composeModify(
+        optionalGen,
+        aGen,
+        funcGen,
+        EQA
+      )
+    },
+    Law("Optional Law: consistent set with modify") {
+      consistentSetModify(
+        optionalGen,
+        aGen,
+        bGen,
+        EQA
+      )
+    },
+    Law("Optional Law: consistent modify with modify identity") {
+      consistentModifyModifyId(
+        optionalGen,
+        aGen,
+        funcGen,
+        EQA
+      )
+    },
+    Law("Optional Law: consistent getOption with modify identity") {
+      consistentGetOptionModifyId(
+        optionalGen,
+        aGen,
+        EQOptionB
+      )
+    }
+  )
+
+  /**
+   * Warning: Use only when a `Gen.constant()` applies
+   */
+  fun <A, B> laws(
+    optional: Optional<A, B>,
+    aGen: Gen<A>,
+    bGen: Gen<B>,
+    funcGen: Gen<(B) -> B>,
+    EQA: Eq<A>,
+    EQOptionB: Eq<Option<B>>
+  ): List<Law> =
+    laws(Gen.constant(optional), aGen, bGen, funcGen, EQA, EQOptionB)
+
+  fun <A, B> getOptionSet(optionalGen: Gen<Optional<A, B>>, aGen: Gen<A>, EQA: Eq<A>): Unit =
+    forAll(optionalGen, aGen) { optional, a ->
+      optional.run {
+        getOrModify(a).fold(::identity) { set(a, it) }
+          .equalUnderTheLaw(a, EQA)
+      }
+    }
+
+  fun <A, B> setGetOption(
+    optionalGen: Gen<Optional<A, B>>,
+    aGen: Gen<A>,
+    bGen: Gen<B>,
+    EQOptionB: Eq<Option<B>>
+  ): Unit =
+    forAll(optionalGen, aGen, bGen) { optional, a, b ->
+      optional.run {
+        getOption(set(a, b))
+          .equalUnderTheLaw(getOption(a).map { b }, EQOptionB)
+      }
+    }
+
+  fun <A, B> setIdempotent(optionalGen: Gen<Optional<A, B>>, aGen: Gen<A>, bGen: Gen<B>, EQA: Eq<A>): Unit =
+    forAll(optionalGen, aGen, bGen) { optional, a, b ->
+      optional.run {
+        set(set(a, b), b)
+          .equalUnderTheLaw(set(a, b), EQA)
+      }
+    }
+
+  fun <A, B> modifyIdentity(optionalGen: Gen<Optional<A, B>>, aGen: Gen<A>, EQA: Eq<A>): Unit =
+    forAll(optionalGen, aGen) { optional, a ->
+      optional.run {
+        modify(a, ::identity)
+          .equalUnderTheLaw(a, EQA)
+      }
+    }
+
+  fun <A, B> composeModify(optionalGen: Gen<Optional<A, B>>, aGen: Gen<A>, funcGen: Gen<(B) -> B>, EQA: Eq<A>): Unit =
+    forAll(optionalGen, aGen, funcGen, funcGen) { optional, a, f, g ->
+      optional.run {
+        modify(modify(a, f), g)
+          .equalUnderTheLaw(modify(a, g compose f), EQA)
+      }
+    }
+
+  fun <A, B> consistentSetModify(optionalGen: Gen<Optional<A, B>>, aGen: Gen<A>, bGen: Gen<B>, EQA: Eq<A>): Unit =
+    forAll(optionalGen, aGen, bGen) { optional, a, b ->
+      optional.run {
+        set(a, b)
+          .equalUnderTheLaw(modify(a) { b }, EQA)
+      }
+    }
+
+  fun <A, B> consistentModifyModifyId(
+    optionalGen: Gen<Optional<A, B>>,
+    aGen: Gen<A>,
+    funcGen: Gen<(B) -> B>,
+    EQA: Eq<A>
+  ): Unit =
+    forAll(optionalGen, aGen, funcGen) { optional, a, f ->
+      optional.run {
+        modify(a, f)
+          .equalUnderTheLaw(modifyF(Id.applicative(), a) { Id.just(f(it)) }.value(), EQA)
+      }
+    }
+
+  fun <A, B> consistentGetOptionModifyId(
+    optionalGen: Gen<Optional<A, B>>,
+    aGen: Gen<A>,
+    EQOptionB: Eq<Option<B>>
+  ) {
+    val firstMonoid = object : Monoid<FirstOption<B>> {
+      override fun empty(): FirstOption<B> =
+        FirstOption(None)
+      override fun FirstOption<B>.combine(b: FirstOption<B>): FirstOption<B> =
+        if (option.fold({ false }, { true })) this else b
+    }
+
+    forAll(optionalGen, aGen) { optional, a ->
+      optional.run {
+        modifyF(Const.applicative(firstMonoid), a) { b ->
+          Const(FirstOption(Some(b)))
+        }.value().option.equalUnderTheLaw(getOption(a), EQOptionB)
+      }
+    }
+  }
+
+  @PublishedApi
+  internal data class FirstOption<A>(val option: Option<A>)
+}

--- a/helios-test/src/main/kotlin/helios/arrow/laws/PrismLaws.kt
+++ b/helios-test/src/main/kotlin/helios/arrow/laws/PrismLaws.kt
@@ -1,20 +1,11 @@
 package helios.arrow.laws
 
-import arrow.core.Id
-import arrow.core.None
-import arrow.core.Option
-import arrow.core.Some
-import arrow.core.compose
-import arrow.core.identity
+import arrow.core.*
 import arrow.core.extensions.const.applicative.applicative
 import arrow.core.extensions.id.applicative.applicative
-import arrow.core.orElse
-import arrow.core.value
 import arrow.optics.Prism
-import arrow.typeclasses.Const
 import arrow.typeclasses.Eq
 import arrow.typeclasses.Monoid
-import arrow.typeclasses.value
 import io.kotest.properties.Gen
 import io.kotest.properties.forAll
 

--- a/helios-test/src/main/kotlin/helios/arrow/laws/PrismLaws.kt
+++ b/helios-test/src/main/kotlin/helios/arrow/laws/PrismLaws.kt
@@ -1,0 +1,73 @@
+package helios.arrow.laws
+
+import arrow.core.Id
+import arrow.core.None
+import arrow.core.Option
+import arrow.core.Some
+import arrow.core.compose
+import arrow.core.identity
+import arrow.core.extensions.const.applicative.applicative
+import arrow.core.extensions.id.applicative.applicative
+import arrow.core.orElse
+import arrow.core.value
+import arrow.optics.Prism
+import arrow.typeclasses.Const
+import arrow.typeclasses.Eq
+import arrow.typeclasses.Monoid
+import arrow.typeclasses.value
+import io.kotest.properties.Gen
+import io.kotest.properties.forAll
+
+object PrismLaws {
+
+  fun <A, B> laws(prism: Prism<A, B>, aGen: Gen<A>, bGen: Gen<B>, funcGen: Gen<(B) -> B>, EQA: Eq<A>, EQOptionB: Eq<Option<B>>): List<Law> = listOf(
+    Law("Prism law: partial round trip one way") { prism.partialRoundTripOneWay(aGen, EQA) },
+    Law("Prism law: round trip other way") { prism.roundTripOtherWay(bGen, EQOptionB) },
+    Law("Prism law: modify identity") { prism.modifyIdentity(aGen, EQA) },
+    Law("Prism law: compose modify") { prism.composeModify(aGen, funcGen, EQA) },
+    Law("Prism law: consistent set modify") { prism.consistentSetModify(aGen, bGen, EQA) },
+    Law("Prism law: consistent modify with modifyF Id") { prism.consistentModifyModifyFId(aGen, funcGen, EQA) },
+    Law("Prism law: consistent get option modify id") { prism.consistentGetOptionModifyId(aGen, EQOptionB) }
+  )
+
+  fun <A, B> Prism<A, B>.partialRoundTripOneWay(aGen: Gen<A>, EQA: Eq<A>): Unit =
+    forAll(aGen) { a ->
+      getOrModify(a).fold(::identity, ::reverseGet)
+        .equalUnderTheLaw(a, EQA)
+    }
+
+  fun <A, B> Prism<A, B>.roundTripOtherWay(bGen: Gen<B>, EQOptionB: Eq<Option<B>>): Unit =
+    forAll(bGen) { b ->
+      getOption(reverseGet(b))
+        .equalUnderTheLaw(Some(b), EQOptionB)
+    }
+
+  fun <A, B> Prism<A, B>.modifyIdentity(aGen: Gen<A>, EQA: Eq<A>): Unit =
+    forAll(aGen) { a ->
+      modify(a, ::identity).equalUnderTheLaw(a, EQA)
+    }
+
+  fun <A, B> Prism<A, B>.composeModify(aGen: Gen<A>, funcGen: Gen<(B) -> B>, EQA: Eq<A>): Unit =
+    forAll(aGen, funcGen, funcGen) { a, f, g ->
+      modify(modify(a, f), g).equalUnderTheLaw(modify(a, g compose f), EQA)
+    }
+
+  fun <A, B> Prism<A, B>.consistentSetModify(aGen: Gen<A>, bGen: Gen<B>, EQA: Eq<A>): Unit =
+    forAll(aGen, bGen) { a, b ->
+      set(a, b).equalUnderTheLaw(modify(a) { b }, EQA)
+    }
+
+  fun <A, B> Prism<A, B>.consistentModifyModifyFId(aGen: Gen<A>, funcGen: Gen<(B) -> B>, EQA: Eq<A>): Unit =
+    forAll(aGen, funcGen) { a, f ->
+      modifyF(Id.applicative(), a) { Id.just(f(it)) }.value().equalUnderTheLaw(modify(a, f), EQA)
+    }
+
+  fun <A, B> Prism<A, B>.consistentGetOptionModifyId(aGen: Gen<A>, EQOptionB: Eq<Option<B>>): Unit =
+    forAll(aGen) { a ->
+      modifyF(Const.applicative(object : Monoid<Option<B>> {
+        override fun Option<B>.combine(b: Option<B>): Option<B> = orElse { b }
+
+        override fun empty(): Option<B> = None
+      }), a) { Const(Some(it)) }.value().equalUnderTheLaw(getOption(a), EQOptionB)
+    }
+}

--- a/helios-test/src/main/kotlin/helios/arrow/laws/TraversalLaws.kt
+++ b/helios-test/src/main/kotlin/helios/arrow/laws/TraversalLaws.kt
@@ -1,0 +1,51 @@
+package helios.arrow.laws
+
+import arrow.core.Option
+import arrow.core.compose
+import arrow.core.identity
+import arrow.core.toOption
+import arrow.core.ListK
+import arrow.optics.Traversal
+import arrow.typeclasses.Eq
+import io.kotest.properties.Gen
+import io.kotest.properties.forAll
+
+object TraversalLaws {
+
+  fun <A, B : Any> laws(traversal: Traversal<A, B>, aGen: Gen<A>, bGen: Gen<B>, funcGen: Gen<(B) -> B>, EQA: Eq<A>, EQOptionB: Eq<Option<B>>, EQListB: Eq<ListK<B>>) = listOf(
+    Law("Traversal law: head option") { traversal.headOption(aGen, EQOptionB) },
+    Law("Traversal law: modify get all") { traversal.modifyGetAll(aGen, funcGen, EQListB) },
+    Law("Traversal law: set is idempotent") { traversal.setIdempotent(aGen, bGen, EQA) },
+    Law("Traversal law: modify identity") { traversal.modifyIdentity(aGen, EQA) },
+    Law("Traversal law: compose modify") { traversal.composeModify(aGen, funcGen, EQA) }
+  )
+
+  fun <A, B : Any> Traversal<A, B>.headOption(aGen: Gen<A>, EQOptionB: Eq<Option<B>>): Unit =
+    forAll(aGen) { a ->
+      headOption(a)
+        .equalUnderTheLaw(getAll(a).firstOrNull().toOption(), EQOptionB)
+    }
+
+  fun <A, B> Traversal<A, B>.modifyGetAll(aGen: Gen<A>, funcGen: Gen<(B) -> B>, EQListB: Eq<ListK<B>>): Unit =
+    forAll(aGen, funcGen) { a, f ->
+      getAll(modify(a, f))
+        .equalUnderTheLaw(getAll(a).map(f), EQListB)
+    }
+
+  fun <A, B> Traversal<A, B>.setIdempotent(aGen: Gen<A>, bGen: Gen<B>, EQA: Eq<A>): Unit =
+    forAll(aGen, bGen) { a, b ->
+      set(set(a, b), b)
+        .equalUnderTheLaw(set(a, b), EQA)
+    }
+
+  fun <A, B> Traversal<A, B>.modifyIdentity(aGen: Gen<A>, EQA: Eq<A>): Unit =
+    forAll(aGen) { a ->
+      modify(a, ::identity).equalUnderTheLaw(a, EQA)
+    }
+
+  fun <A, B> Traversal<A, B>.composeModify(aGen: Gen<A>, funcGen: Gen<(B) -> B>, EQA: Eq<A>): Unit =
+    forAll(aGen, funcGen, funcGen) { a, f, g ->
+      modify(modify(a, f), g)
+        .equalUnderTheLaw(modify(a, g compose f), EQA)
+    }
+}

--- a/helios-test/src/main/kotlin/helios/test/generators/JsonGenerators.kt
+++ b/helios-test/src/main/kotlin/helios/test/generators/JsonGenerators.kt
@@ -5,7 +5,7 @@ package helios.test.generators
 import arrow.core.identity
 import helios.core.*
 import helios.typeclasses.Encoder
-import io.kotlintest.properties.Gen
+import io.kotest.properties.*
 
 private fun genJson(): Gen<Json> =
   Gen.oneOf(

--- a/helios-test/src/main/kotlin/helios/test/generators/extraGenerators.kt
+++ b/helios-test/src/main/kotlin/helios/test/generators/extraGenerators.kt
@@ -1,6 +1,6 @@
 package helios.test.generators
 
-import io.kotlintest.properties.Gen
+import io.kotest.properties.*
 import java.math.BigDecimal
 
 fun Gen.Companion.alphaStr() =


### PR DESCRIPTION
Close #119, I updated Arrow version 0.10.0

Everything works fine but there are more warnings when building than before. I don't know should I fix them now or do it in another PR.

I also had to update kotlintest library version `3.4.1` because tests were broken with old kotlintest version `3.1.11`.
