### PR TITLE
Make the task "detekt" incremental

### DIFF
--- a/detekt.gradle
+++ b/detekt.gradle
@@ -7,16 +7,23 @@ repositories {
         detekt
     }
 
+    def reportFile = "$project.projectDir.absolutePath/reports/detekt.txt"
+
     task detekt(type: JavaExec) {
         group = "verification"
         main = "io.gitlab.arturbosch.detekt.cli.Main"
         classpath = configurations.detekt
         def input = "$project.projectDir.absolutePath"
         def config = "$project.projectDir/detekt.yml"
-        def reports = "helios:$project.projectDir.absolutePath/reports/report.detekt"
+        def reports = "txt:$reportFile"
         def baseline = "$project.projectDir.absolutePath/reports/baseline.xml"
         def filters = ".*test.*"
         def params = ["-i", input, "-c", config, "-f", filters, "-r", reports, "-b", baseline]
+        subprojects.each{subproject ->
+            inputs.files fileTree(subproject.projectDir).include("**/src/main/kotlin/**/*.kt")
+        }
+        inputs.file config
+        outputs.file reportFile
         args(params)
     }
 
@@ -26,10 +33,15 @@ repositories {
         classpath = configurations.detekt
         def input = "$project.projectDir.absolutePath"
         def config = "$project.projectDir/detekt.yml"
-        def reports = "helios:$project.projectDir.absolutePath/reports/report.detekt"
+        def reports = "txt:$reportFile"
         def baseline = "$project.projectDir.absolutePath/reports/baseline.xml"
         def filters = ".*test.*"
         def params = ["-i", input, "-c", config, "-f", filters, "-r", reports, "-b", baseline, "-cb"]
+        subprojects.each{subproject ->
+            inputs.files fileTree(subproject.projectDir).include("**/src/main/kotlin/**/*.kt")
+        }
+        inputs.file config
+        outputs.file reportFile
         args(params)
     }
 


### PR DESCRIPTION
Hi

This commit fixes the time-consuming task "detekt".
First, it makes the task incremental by defining its inputs (i.e., all Kotlin source files) and its output (e.g., the generated report). In this way, this time consuming task only runs, whenever there is any change in the kotlin files.

Second, it fixes the argument given in the `-r` option of the command. The documentation states (See [here](https://arturbosch.github.io/detekt/cli.html) that this option expects an entry that should consist of `[report-id:path]`.  Available 'report-id' values are 'txt', 'xml', 'html'. So, the value `helios` is not acceptable as a report-id.