### PR TITLE
Integration Xebia Functional

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -4,7 +4,7 @@ name: '{Helios}'
 #-------------------------
 description: '{Helios} is a purely functional JSON library for Kotlin built on Arrow'
 #-------------------------
-author: 47 Degrees
+author: Xebia Functional
 keywords: functional-programming, kotlin-library, arrow, monads, monad-transformers, functional-data-structure, kotlin, fp-types, adt, free-monads, tagless-final, mtl, for-comprehension, category-theory
 #-------------------------
 url: https://www.47deg.com


### PR DESCRIPTION
In this PR we have changed the references of the 47 Degrees microsite to Xebia Functional. We have not changed the references to the twitter account, web address, Github...